### PR TITLE
Re-purpose the render route to save the script to disk

### DIFF
--- a/api/app.rb
+++ b/api/app.rb
@@ -46,7 +46,7 @@ class App < Sinatra::Base
 
   helpers do
     def role
-      case FlightJobScriptAPI::PamAuth.valid?(env['HTTP_AUTHORIZATION'])
+      case FlightJobScriptAPI::PamAuth.build(env['HTTP_AUTHORIZATION']).valid?
       when true
         :user
       when false
@@ -148,7 +148,7 @@ end
 # /:version/render
 class RenderApp < Sinatra::Base
   before do
-    case FlightJobScriptAPI::PamAuth.valid?(env['HTTP_AUTHORIZATION'])
+    case FlightJobScriptAPI::PamAuth.build(env['HTTP_AUTHORIZATION']).valid?
     when false
       status 403
       halt

--- a/api/app.rb
+++ b/api/app.rb
@@ -148,7 +148,10 @@ end
 # /:version/render
 class RenderApp < Sinatra::Base
   before do
-    case FlightJobScriptAPI::PamAuth.build(env['HTTP_AUTHORIZATION']).valid?
+    auth = FlightJobScriptAPI::PamAuth.build(env['HTTP_AUTHORIZATION'])
+    case auth.valid?
+    when true
+      @current_user = auth.username
     when false
       status 403
       halt
@@ -167,7 +170,6 @@ class RenderApp < Sinatra::Base
   post '/:id' do
     template = Template.new(id: params['id'])
     if template.valid?
-      attachment(template.metadata['name'], :attachment)
       response.headers['Content-Type'] = 'text/plain'
 
       context = FlightJobScriptAPI::RenderContext.new(
@@ -175,7 +177,7 @@ class RenderApp < Sinatra::Base
       )
 
       begin
-        payload = context.render
+        content = context.render
       rescue
         FlightJobScriptAPI.logger.error("Failed to render: #{template.template_path}")
         FlightJobScriptAPI.logger.debug("Full render error:") do
@@ -185,8 +187,16 @@ class RenderApp < Sinatra::Base
         halt
       end
 
-      status 200
-      next payload
+      # Writes the rendered content down
+      base = File.join('.local/share/flight/job-scripts', template.id, "#{template.script_template_name}-#{Time.now.to_i}")
+      path = File.expand_path(base, Etc.getpwnam(@current_user).dir)
+      FileUtils.mkdir_p File.dirname(path)
+      File.write(path, content)
+      FileUtils.chmod(0700, path)
+      FileUtils.chown(@current_user, @current_user, path)
+
+      status 201
+      next path
     else
       status 404
       halt

--- a/api/app/models/template.rb
+++ b/api/app/models/template.rb
@@ -120,8 +120,11 @@ class Template < ApplicationModel
   end
 
   def template_path
-    template = metadata.fetch('script_template', 'script.sh')
-    File.join(FlightJobScriptAPI.config.data_dir, id, "#{template}.erb")
+    File.join(FlightJobScriptAPI.config.data_dir, id, "#{script_template_name}.erb")
+  end
+
+  def script_template_name
+    metadata.fetch('script_template', 'script.sh')
   end
 
   # NOTE: The metadata is intentionally cached to prevent excess file reads during

--- a/api/config/boot.rb
+++ b/api/config/boot.rb
@@ -36,6 +36,7 @@ require 'json'
 require 'pathname'
 require 'ostruct'
 require 'erb'
+require 'etc'
 require 'logger'
 
 if ENV['RACK_ENV'] == 'development'

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -228,7 +228,7 @@ Content-Type: application/vnd.api+json
 
 ## GET - /render/:template_id
 
-Renders the template against the provided date.
+Renders the template against the provided date and saves it to the filesystem. Returns the path to the rendered script.
 
 Due to the underlining templating engine, this route could fail to render for various reasons including but not limited to:
 1. The client not sending all the required keys, or
@@ -246,10 +246,9 @@ Content-Type: x-www-form-urlencoded
 Accept: text/plain
 key=value&...
 
-HTTP/2 200 OK
-Content-Disposition: attachment; filename="<template_id>"
+HTTP/2 201 CREATED
 Content-Type: text/plain
-... rendered template ...
+/path/to/rendered/script
 
 
 # With application/json body
@@ -262,10 +261,9 @@ Accept: text/plain
   ...
 }
 
-HTTP/2 200 OK
-Content-Disposition: attachment; filename="<template_id>"
+HTTP/2 201 CREATED
 Content-Type: text/plain
-... rendered template ...
+/path/to/rendered/script
 
 
 # When the template fails to render


### PR DESCRIPTION
The `/render/:foo` route works broadly the same way as it did before except:

1. It saves the rendered file to disk,
2. It returns the scripts path with the request, and
3. The successful status code is now 201

In making the change, the new `script_template` metadata parameter is now used to dictate the filename along with unix-epoch timestamp.

The `name` metadata parameter is not used within the API anymore, but is exposed by id.

Based on #6 