### PR TITLE
Executes the rendered scripts

### DIFF
--- a/api/app.rb
+++ b/api/app.rb
@@ -178,6 +178,7 @@ class App < Sinatra::Base
     helpers do
       def validate!
         resource.validate!
+        resource.run
       end
     end
 

--- a/api/app.rb
+++ b/api/app.rb
@@ -136,6 +136,10 @@ class App < Sinatra::Base
     end
   end
 
+  resource :scripts do
+    index  { [] }
+  end
+
   freeze_jsonapi
 end
 

--- a/api/app.rb
+++ b/api/app.rb
@@ -30,10 +30,16 @@ require 'sinatra/base'
 require 'sinatra/jsonapi'
 require_relative 'app/autoload'
 
-# Adds 401 Unauthorized error
+# Additional error codes
 module Sinja
   class UnauthorizedError < HttpError
     HTTP_STATUS = 401
+
+    def initialize(*args) super(HTTP_STATUS, *args) end
+  end
+
+  class ServiceUnavailable < HttpError
+    HTTP_STATUS = 503
 
     def initialize(*args) super(HTTP_STATUS, *args) end
   end
@@ -178,10 +184,9 @@ class App < Sinatra::Base
     helpers do
       def validate!
         resource.validate!
-        resource.run
-
-        # Ensure the resource is still valid after execution
-        resource.validate!
+        unless resource.run
+          raise Sinja::ServiceUnavailable, 'could not schedule the script'
+        end
       end
     end
 

--- a/api/app.rb
+++ b/api/app.rb
@@ -161,6 +161,10 @@ class App < Sinatra::Base
     end
 
     show
+
+    destroy do
+      FileUtils.rm_rf File.dirname(resource.metadata_path)
+    end
   end
 
   freeze_jsonapi

--- a/api/app.rb
+++ b/api/app.rb
@@ -179,6 +179,9 @@ class App < Sinatra::Base
       def validate!
         resource.validate!
         resource.run
+
+        # Ensure the resource is still valid after execution
+        resource.validate!
       end
     end
 

--- a/api/app/models/script.rb
+++ b/api/app/models/script.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
+#
+# This file is part of Flight Job Script Service.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Job Script Service is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Job Script Service. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Job Script Service, please visit:
+# https://github.com/openflighthpc/flight-job-script-service
+#==============================================================================
+
+class Script < ApplicationModel
+  attr_accessor :template, :unix_timestamp, :user
+
+  # XXX: Eventually the answers will likely be saved with the script
+  def render_and_save(**answers)
+    content = FlightJobScriptAPI::RenderContext.new(
+      template: template, answers: answers
+    ).render
+    FileUtils.mkdir_p File.dirname(path)
+    File.write(path, content)
+    FileUtils.chmod(0700, path)
+    FileUtils.chown(user, user, path)
+  rescue
+    FlightJobScriptAPI.logger.error("Failed to render: #{template.template_path}")
+    FlightJobScriptAPI.logger.debug("Full render error:") do
+      $!.full_message
+    end
+    raise $!
+  end
+
+  def path
+    @path ||= File.expand_path(File.join(
+      Etc.getpwnam(user).dir, '.local/share/flight/job-scripts', template.id,
+      "#{template.script_template_name}-#{unix_timestamp}"
+    ))
+  end
+end

--- a/api/app/models/script.rb
+++ b/api/app/models/script.rb
@@ -105,16 +105,16 @@ class Script < ApplicationModel
     if ! @metadata.nil?
       @metadata
     elsif ! metadata_path
-      @metadata = false
+      @metadata = {}
     elsif @template && File.exists?(metadata_path)
       errors.add(:metadata, 'detected a template conflict')
-      @metadata = false
+      @metadata = {}
     elsif File.exists?(metadata_path)
       begin
         YAML.load File.read(metadata_path)
       rescue Psych::SyntaxError
         errors.add(:metadata, 'is not valid YAML')
-        @metadata = false
+        @metadata = {}
       end
     elsif @template
       @metadata = {
@@ -124,7 +124,7 @@ class Script < ApplicationModel
       }
     else
       errors.add(:template, 'no template provided')
-      @metadata = false
+      @metadata = {}
     end
   end
 

--- a/api/app/models/submission.rb
+++ b/api/app/models/submission.rb
@@ -81,13 +81,17 @@ class Submission < ApplicationModel
       Kernel.exec(env, *cmd, unsetenv_others: true, close_others: true)
     end
 
+    # Run the command
     begin
-      _, @status = Timeout.timeout(FlightJobScriptAPI.app.config.command_timeout) do
+      _, status = Timeout.timeout(FlightJobScriptAPI.app.config.command_timeout) do
         Process.wait2(pid)
       end
     rescue Timeout::Error
       Process.kill('TERM', pid)
       retry
     end
+
+    # Report back if it was successful
+    status.success?
   end
 end

--- a/api/app/models/submission.rb
+++ b/api/app/models/submission.rb
@@ -38,12 +38,6 @@ class Submission < ApplicationModel
     errors.add(:script, 'does not exist')
   end
 
-  validate do
-    next unless @status
-    next if @status.success?
-    errors.add(:success, 'failed to run')
-  end
-
   def id
     @id ||= SecureRandom.uuid
   end

--- a/api/app/models/submission.rb
+++ b/api/app/models/submission.rb
@@ -72,7 +72,7 @@ class Submission < ApplicationModel
         'USER' => script.user,
         'LOGNAME' => script.user
       }
-      Kernel.exec(env, *cmd, unsetenv_others: true, close_others: true)
+      Kernel.exec(env, *cmd, unsetenv_others: true, close_others: true, chdir: passwd.dir)
     end
 
     # Run the command

--- a/api/app/models/submission.rb
+++ b/api/app/models/submission.rb
@@ -66,9 +66,13 @@ class Submission < ApplicationModel
       Process.setsid
 
       # Execute the command
-      # NOTE: What should happen to STDOUT/ STDERR?
-      # Currently they are being redirected to the log file
-      Kernel.exec({}, *cmd, unsetenv_others: true, close_others: true)
+      env = {
+        'PATH' => FlightJobScriptAPI.app.config.command_path,
+        'HOME' => passwd.dir,
+        'USER' => script.user,
+        'LOGNAME' => script.user
+      }
+      Kernel.exec(env, *cmd, unsetenv_others: true, close_others: true)
     end
     Process.detach(pid)
   end

--- a/api/app/serializers/script_serializer.rb
+++ b/api/app/serializers/script_serializer.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
+#
+# This file is part of Flight Job Script Service.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Job Script Service is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Job Script Service. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Job Script Service, please visit:
+# https://github.com/openflighthpc/flight-job-script-service
+#==============================================================================
+
+class ScriptSerializer < ApplicationSerializer
+  attributes :script_path, :script_name
+  attribute(:created_at) { object.metadata['created_at'] }
+
+  has_one :template
+end

--- a/api/app/serializers/script_serializer.rb
+++ b/api/app/serializers/script_serializer.rb
@@ -30,5 +30,7 @@ class ScriptSerializer < ApplicationSerializer
   attributes :script_path, :script_name
   attribute(:created_at) { object.metadata['created_at'] }
 
-  has_one :template
+  # The model uses nil/false inter-changeable,
+  # this distinction is hidden by the API
+  has_one(:template) { object.template ? object.template : nil }
 end

--- a/api/app/serializers/submission_serializer.rb
+++ b/api/app/serializers/submission_serializer.rb
@@ -26,37 +26,6 @@
 # https://github.com/openflighthpc/flight-job-script-service
 #==============================================================================
 
-ENV['RACK_ENV'] ||= 'development'
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-
-require 'rubygems'
-require 'bundler'
-require 'yaml'
-require 'json'
-require 'pathname'
-require 'ostruct'
-require 'erb'
-require 'etc'
-require 'logger'
-
-if ENV['RACK_ENV'] == 'development'
-  Bundler.require(:default, :development)
-else
-  Bundler.require(:default)
+class SubmissionSerializer < ApplicationSerializer
+  has_one :script
 end
-
-# Shared activesupport libraries
-require 'active_support/core_ext/hash/keys'
-
-# Ensure ApplicationModel::ValidationError is defined in advance
-require 'active_model/validations.rb'
-
-lib = File.expand_path('../lib', __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-
-require 'flight_job_script_api'
-
-# Ensures the config has been loaded
-FlightJobScriptAPI.load_configuration
-
-require_relative '../app'

--- a/api/app/serializers/submission_serializer.rb
+++ b/api/app/serializers/submission_serializer.rb
@@ -27,8 +27,5 @@
 #==============================================================================
 
 class SubmissionSerializer < ApplicationSerializer
-  # Submissions are only ever created in a successful state, revisit as required
-  attribute(:success) { true }
-
   has_one :script
 end

--- a/api/app/serializers/submission_serializer.rb
+++ b/api/app/serializers/submission_serializer.rb
@@ -27,5 +27,8 @@
 #==============================================================================
 
 class SubmissionSerializer < ApplicationSerializer
+  # Submissions are only ever created in a successful state, revisit as required
+  attribute(:success) { true }
+
   has_one :script
 end

--- a/api/config/boot.rb
+++ b/api/config/boot.rb
@@ -37,6 +37,7 @@ require 'pathname'
 require 'ostruct'
 require 'erb'
 require 'etc'
+require 'timeout'
 require 'logger'
 
 if ENV['RACK_ENV'] == 'development'

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -137,7 +137,7 @@ Content-Type: application/vnd.api+json
 
 ## GET - /templates/:id
 
-Returns the `template` given by the `id`. The `id` should include the file extension if there is one (excluding `.erb`). The returned object is referred to as a `TemplateResource` within this document.
+Returns the `template` given by the `id`. The returned object is referred to as a `TemplateResource` within this document.
 
 ```
 GET /templates/:id
@@ -150,7 +150,7 @@ Content-Type: application/vnd.api+json
   "data": {                       # REQUIRED - The TemplateResource object
     "type": "templates",          # REQUIRED - Specifes the response as a template
     "id": "<id>",                 # REQUIRED - The template id
-    "attributes": {               # REQUIRED - Template Attributes
+    "attributes": {
       "name": STRING,             # REQUIRED - The name of the template including the file extension
       "synopsis": STRING,         # REQUIRED - A short summary of the template
       "description": STRING,      # OPTIONAL - A longer description of the template
@@ -159,7 +159,7 @@ Content-Type: application/vnd.api+json
     "links": {                    # REQUIRED - Self reference to the resource
       "self": "/templates/<id>"
     },
-    "relationships": {            # REQURIED - References to other resources
+    "relationships": {
       "questions": {              # REQUIRED - References to the template's questions
         "links": {
           "self": "/templates/:id/relationships/questions",
@@ -192,7 +192,7 @@ Content-Type: application/vnd.api+json
     {
       "type": "questions",      # REQUIRED    - Specifies the response is a question
       "id": "<question_id>"     # REQUIRED    - Gives the question's ID
-      "attributes": {           # REQUIRED    - Quesion attributes
+      "attributes": {
         "text": STRING,         # REQUIRED    - A short summary of the question
         "description": STRING,  # OPTIONAL    - A longer description of the question
         "default": STRING,      # OPTIONAL    - The value which should pre-populate the question
@@ -225,6 +225,236 @@ Content-Type: application/vnd.api+json
 }
 ```
 
+
+## GET - /scripts
+
+Return a list of all `scripts` for the given user.
+
+```
+GET /scripts
+Authorization: Basic <base64 username:password>
+Accept: application/vnd.api+json
+
+HTTP/2 200 OK
+Content-Type: application/vnd.api+json
+{
+  "data": [
+    ScriptResource,
+    ...
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "included": [
+  ]
+}
+```
+
+Return the same list with all the related templates.
+NOTE: Templates which the user has not used will not be included in the response
+
+```
+GET /scripts?include=template
+Authorization: Basic <base64 username:password>
+Accept: application/vnd.api+json
+
+HTTP/2 200 OK
+Content-Type: application/vnd.api+json
+{
+  "data": [
+    ScriptResource,
+    ...
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "included": [
+    TemplateResource,
+    ...
+  ]
+}
+```
+
+## GET - /scripts/:id
+
+Return the `script` given by the `id`. The returned object is referred to as a `ScriptResource` object within this document.
+
+```
+get /scripts/:id
+authorization: basic <base64 username:password>
+accept: application/vnd.api+json
+
+http/2 200 ok
+content-type: application/vnd.api+json
+{
+  "data": {                     # REQUIRED - The ScreiptResource
+    "type": "scripts",          # REQUIRED - Specfies the resource is a script
+    "id": STRING,               # REQUIRED - The script's ID
+    "attributes": {
+      "script-path": STRING,    # REQUIRED - The path to the rendered script
+      "script-name": STRING,    # REQUIRED - The name of the script
+      "created-at": STRING      # REQUIRED - The creation date-time in RFC3339 format
+    },
+    "links": {
+      "self": "/scripts/a70d5782-1271-4429-a82d-1221bc06dd2d"
+    },
+    "relationships": {
+      "template": {             # REQUIRED - The related template resource links
+        "links": {
+          "self": "/scripts/:id/relationships/template",
+          "related": "/scripts/:id/template"
+        }
+      }
+    }
+  },
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "included": [
+  ]
+}
+```
+
+The related `template` can also be retrieved along side the request.
+NOTE: All `script` SHOULD have a related `template`, but this is not guaranteed. A related `template` SHALL only be provided if referential integrity can be guaranteed when the request is made.
+
+```
+# Retrieving the related template
+GET /scripts/:id?include=template
+Authorization: Basic <base64 username:password>
+Accept: application/vnd.api+json
+
+HTTP/2 200 OK
+Content-Type: application/vnd.api+json
+
+{
+  "data": {
+    "type": "scripts"
+    "id": STRING,
+    "attributes": {
+      ...
+    },
+    "links": {
+      "self": "/scripts/:id"
+    },
+    "relationships": {
+      "template": {
+        "links": {
+          "self": "/scripts/:id/relationships/template",
+          "related": "/scripts/:id/template"
+        },
+        "data": {
+          "type": "template"      # REQUIRED - Specifies the related resource is a template
+          "id": STRING,           # REQUIRED - Specifies the id of the template
+        }
+      }
+    }
+  },
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "included": [
+    TemplateResource              # REQUIRED - The related TemplateResource object
+  ]
+}
+
+
+# When the related template is missing
+GET /scripts/:id?include=template
+Authorization: Basic <base64 username:password>
+Accept: application/vnd.api+json
+
+HTTP/2 200 OK
+Content-Type: application/vnd.api+json
+
+{
+  "data": {
+    "type": "scripts"
+    "id": STRING,
+    "attributes": {
+      ...
+    },
+    "links": {
+      "self": "/scripts/:id"
+    },
+    "relationships": {
+      "template": {
+        "links": {
+          "self": "/scripts/:id/relationships/template",
+          "related": "/scripts/:id/template"
+        },
+        "data": null
+      }
+    }
+  },
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "included": [
+  ]
+}
+```
+
+## DELETE - /scripts/:id
+
+Permanently remove a script
+
+```
+DELETE /scripts/:id
+Authorization: Basic <base64 username:password>
+Accept: application/vnd.api+json
+
+HTTP/2 204 No Content
+```
+
+## POST - /submissions
+
+Submit an existing script to the scheduler
+
+```
+POST /submissions
+Authorization: Basic <base64 username:password>
+Accept: application/vnd.api+json
+Content-Type: application/vnd.api+json
+{
+  "data": {
+    "type": "submissions",      # REQUIRED - Specify that a submission is being created
+    "relationships": {
+      "script": {               # REQUIRED - Specify the script which will be launched
+        "data": {
+          "type": "scripts",    # REQUIRED - Specify the related object is a script
+          "id": STRING          # REQUIRED - Specify the ID of the related script
+        }
+      }
+    }
+  }
+}
+
+HTTP/2 201 Created
+Content-Type: application/vnd.api+json
+{
+  "data": {
+    "type": "submissions",      # REQUIRED - Specifies a submission has been created
+    "id": STRING,               # REQUIRED - The ID of the submission
+    "links": {
+      "self": "/submissions/:id"
+    },
+    "relationships": {
+      "script": {
+        "links": {
+          "self": "/submissions/:id/relationships/script",
+          "related": "/submissions/:id/script"
+        }
+      }
+    }
+  },
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "included": [
+  ]
+}
+```
 
 ## GET - /render/:template_id
 

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -409,7 +409,7 @@ HTTP/2 204 No Content
 
 ## POST - /submissions
 
-Submit an existing script to the scheduler
+Submit an existing script to the scheduler. Note this route MAY return `503 Service Unavailable` due to the underlining system command failing.
 
 ```
 POST /submissions
@@ -452,6 +452,19 @@ Content-Type: application/vnd.api+json
     "version": "1.0"
   },
   "included": [
+  ]
+}
+
+# When the underlining system command fails
+HTTP/2 503 Service Unavailable
+{
+  "errors": [
+    {
+      "id": ":id",
+      "title": "Service Unavailable",
+      "detail": "could not schedule the script",
+      "status": "503"
+    }
   ]
 }
 ```

--- a/api/etc/flight-job-script-api.development.yaml
+++ b/api/etc/flight-job-script-api.development.yaml
@@ -27,3 +27,4 @@
 
 bind_address: tcp://0.0.0.0:6310
 log_level: debug
+scheduler_command: "/tmp/slow-script"

--- a/api/etc/flight-job-script-api.development.yaml
+++ b/api/etc/flight-job-script-api.development.yaml
@@ -27,4 +27,3 @@
 
 bind_address: tcp://0.0.0.0:6310
 log_level: debug
-scheduler_command: "/tmp/slow-script"

--- a/api/etc/flight-job-script-api.yaml
+++ b/api/etc/flight-job-script-api.yaml
@@ -58,6 +58,14 @@
 # scheduler_comand: sbatch
 
 #-------------------------------------------------------------------------------
+# Command PATH
+# The PATH the scheduler command will be executed with. This is a global value
+# for all users.
+# The environment variable FLIGHT_JOB_SCRIPT_COMMAND_PATH takes precedence
+#-------------------------------------------------------------------------------
+# command_path: /usr/sbin:/usr/bin:/sbin:/bin
+
+#-------------------------------------------------------------------------------
 # Data Directory
 # Specify the directory for internal runtime data
 # The environment variable FLIGHT_JOB_SCRIPT_API_DATA_DIR takes precedence

--- a/api/etc/flight-job-script-api.yaml
+++ b/api/etc/flight-job-script-api.yaml
@@ -66,6 +66,13 @@
 # command_path: /usr/sbin:/usr/bin:/sbin:/bin
 
 #-------------------------------------------------------------------------------
+# Command Timeout
+# The maximum time to wait when launching a scheduler command. Commands which
+# take longer then this period will be terminated.
+#-------------------------------------------------------------------------------
+# command_timeout: 5
+
+#-------------------------------------------------------------------------------
 # Data Directory
 # Specify the directory for internal runtime data
 # The environment variable FLIGHT_JOB_SCRIPT_API_DATA_DIR takes precedence

--- a/api/etc/flight-job-script-api.yaml
+++ b/api/etc/flight-job-script-api.yaml
@@ -55,7 +55,7 @@
 # Specify the command that will be used to start the submission
 # The environment variable FLIGHT_JOB_SCRIPT_API_SCHEDULER_COMMAND takes precedence
 #-------------------------------------------------------------------------------
-# scheduler_comand: sbatch
+# scheduler_command: sbatch
 
 #-------------------------------------------------------------------------------
 # Command PATH

--- a/api/etc/flight-job-script-api.yaml
+++ b/api/etc/flight-job-script-api.yaml
@@ -51,6 +51,13 @@
 # pam_service: login
 
 #-------------------------------------------------------------------------------
+# Scheduler Command
+# Specify the command that will be used to start the submission
+# The environment variable FLIGHT_JOB_SCRIPT_API_SCHEDULER_COMMAND takes precedence
+#-------------------------------------------------------------------------------
+# scheduler_comand: sbatch
+
+#-------------------------------------------------------------------------------
 # Data Directory
 # Specify the directory for internal runtime data
 # The environment variable FLIGHT_JOB_SCRIPT_API_DATA_DIR takes precedence

--- a/api/lib/flight_job_script_api/configuration.rb
+++ b/api/lib/flight_job_script_api/configuration.rb
@@ -62,6 +62,11 @@ module FlightJobScriptAPI
         default: 'sbatch'
       },
       {
+        name: 'command_path',
+        env_var: true,
+        default: '/usr/sbin:/usr/bin:/sbin:/bin'
+      },
+      {
         name: 'log_level',
         env_var: true,
         default: 'info'

--- a/api/lib/flight_job_script_api/configuration.rb
+++ b/api/lib/flight_job_script_api/configuration.rb
@@ -57,6 +57,11 @@ module FlightJobScriptAPI
         default: ->(root) { root.join('usr/share') }
       },
       {
+        name: 'scheduler_command',
+        env_var: true,
+        default: 'sbatch'
+      },
+      {
         name: 'log_level',
         env_var: true,
         default: 'info'

--- a/api/lib/flight_job_script_api/configuration.rb
+++ b/api/lib/flight_job_script_api/configuration.rb
@@ -67,6 +67,11 @@ module FlightJobScriptAPI
         default: '/usr/sbin:/usr/bin:/sbin:/bin'
       },
       {
+        name: 'command_timeout',
+        env_var: false,
+        default: 5
+      },
+      {
         name: 'log_level',
         env_var: true,
         default: 'info'

--- a/api/spec/controllers/script_controller_spec.rb
+++ b/api/spec/controllers/script_controller_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
+#
+# This file is part of Flight Job Script Service.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Job Script Service is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Job Script Service. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Job Script Service, please visit:
+# https://github.com/openflighthpc/flight-job-script-service
+#==============================================================================
+
+require 'spec_helper'
+
+RSpec.describe '/scripts' do
+  context 'with an authenticated user' do
+    before do
+      allow(Rpam).to receive(:auth).and_return(true)
+      header 'Accept', 'application/vnd.api+json'
+      header 'Authorization', "Basic #{Base64.encode64("#{ENV['USER']}:bar")}"
+    end
+
+    describe '#index' do
+      it "can not find other user's scripts" do
+        script = create(:script, user: 'foobar')
+        get '/scripts'
+        expect(last_response_data.map { |d| d[:id] }).not_to include(script.id)
+      end
+    end
+  end
+end

--- a/api/spec/controllers/script_controller_spec.rb
+++ b/api/spec/controllers/script_controller_spec.rb
@@ -66,6 +66,13 @@ RSpec.describe '/scripts' do
           expect(last_response_data.map { |d| d[:id] }).to include(script.id)
         end
       end
+
+      describe '#show' do
+        specify "accessing the other user's script returns 404" do
+          get "/scripts/#{script.id}"
+          expect(last_response).to be_not_found
+        end
+      end
     end
 
     context "with a user's script" do

--- a/api/spec/factories.rb
+++ b/api/spec/factories.rb
@@ -27,7 +27,7 @@
 #==============================================================================
 
 FactoryBot.define do
-  # NOTE: The template object is intentionally uses save_* attributes on build
+  # NOTE: The template object intentionally uses save_* attributes on build
   # This is because they cannot be considered "valid" before saving
   # This can be disabled by passing in false
   factory :template do
@@ -69,31 +69,12 @@ FactoryBot.define do
     end
   end
 
-  # NOTE: The script object is intentionally not saved to disk on build
-  # This is because they can be considered "valid" before saving
   factory(:script) do
     template
     user { ENV['USER'] }
-    unix_timestamp { Time.now.to_s }
-
-    # Partially redefines some of the methods to allow for users which
-    # do not exist
-    initialize_with do |attr|
-      new(**attributes).tap do |instance|
-        unless user == ENV['USER']
-          instance.instance_variable_set(:@base_path, File.join('/tmp', user))
-        end
-      end
-    end
 
     to_create do |instance|
-      if instance.user == ENV['USER']
-        instance.render_and_save
-      else
-        content = instance.render
-        FileUtils.mkdir_p File.dirname(instance.path)
-        File.write(instance.path, content)
-      end
+      instance.render_and_save
     end
   end
 


### PR DESCRIPTION
This PR implements the following routes:

* `GET /scripts` - Index the scripts for the user
* `GET /scripts/:foo` - Show a particular script
* `DELETE /scripts/:foo` - Remove the script
* `POST /submissions` - Launch a script

After testing out a few different ways, I decided the `id` for a script is a UUID. The creation time and corresponding template are stored in a metadata file along side the script. This proved to be easier then trying to encode the information within the path.

The `metadata` file also stores the `script_name`, which allows the corresponding script to be located even if the `template` is edited. This resolves some of the data integrity issues

There is a bit of logic surrounding a script's `template`, `metadata`, `metadata_path`, and `script_path`. They are interrelated in various ways a they are subtle differences between creating a new script and loading an existing one. There are various tests cases to ensure the routes work, so this should be sufficient for now.

Based on #7 