### PR TITLE
Performance improvements

### DIFF
--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -68,6 +68,8 @@ GEM
       rack (>= 1.0, < 3)
     rake (13.0.3)
     regexp_parser (2.0.3)
+    request_store (1.5.0)
+      rack (>= 1.4)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -127,6 +129,7 @@ DEPENDENCIES
   rack-parser
   rack-test
   rake
+  request_store
   rspec
   rspec-collection_matchers
   sinatra

--- a/api/app.rb
+++ b/api/app.rb
@@ -112,7 +112,7 @@ class App < Sinatra::Base
   resource :templates, pkre: /[\w.-]+/ do
     helpers do
       def find(id)
-        Template.find(id, user: current_user)
+        Template.find!(id, user: current_user)
       end
     end
 
@@ -130,7 +130,7 @@ class App < Sinatra::Base
   resource :scripts, pkre: /[\w-]+/ do
     helpers do
       def find(id)
-        Script.find(id, user: current_user)
+        Script.find!(id, user: current_user)
       end
     end
 
@@ -146,7 +146,7 @@ class App < Sinatra::Base
   resource :jobs, pkre: /[\w-]+/ do
     helpers do
       def find(id)
-        Job.find(id, user: current_user)
+        Job.find!(id, user: current_user)
       end
 
       def validate!

--- a/api/app.rb
+++ b/api/app.rb
@@ -73,6 +73,10 @@ class App < Sinatra::Base
         raise Sinja::UnauthorizedError, 'Could not authenticate your authorization credentials'
       end
     end
+
+    def includes?(resource_name)
+      ( params['include'] || [] ).include?(resource_name)
+    end
   end
 
   configure_jsonapi do |c|
@@ -135,6 +139,7 @@ class App < Sinatra::Base
     end
 
     index do
+      Template.index(user: current_user) if includes?('template')
       Script.index(user: current_user)
     end
 
@@ -159,6 +164,7 @@ class App < Sinatra::Base
     end
 
     index do
+      Script.index(user: current_user) if includes?('script')
       Job.index(user: current_user)
     end
 

--- a/api/app/models/job.rb
+++ b/api/app/models/job.rb
@@ -43,6 +43,12 @@ class Job
     end
 
     def find(id, **opts)
+      find!(id, **opts)
+    rescue FlightJobScriptAPI::CommandError
+      nil
+    end
+
+    def find!(id, **opts)
       cmd = FlightJobScriptAPI::SystemCommand.flight_info_job(id, **opts).tap do |cmd|
         next if cmd.exitstatus == 0
         return nil if cmd.exitstatus == 23

--- a/api/app/models/job.rb
+++ b/api/app/models/job.rb
@@ -29,24 +29,28 @@
 class Job
   class MissingScript < StandardError; end
 
-  def self.index(**opts)
-    cmd = FlightJobScriptAPI::SystemCommand.flight_list_jobs(**opts).tap do |cmd|
-      next if cmd.exitstatus == 0
-      raise FlightJobScriptAPI::CommandError, 'Unexpectedly failed to list jobs'
-    end
-    JSON.parse(cmd.stdout).map do |metadata|
-      new(user: opts[:user], **metadata)
-    end
-  end
+  class << self
+    prepend FlightJobScriptAPI::ModelCache
 
-  def self.find(id, **opts)
-    cmd = FlightJobScriptAPI::SystemCommand.flight_info_job(id, **opts).tap do |cmd|
-      next if cmd.exitstatus == 0
-      return nil if cmd.exitstatus == 23
-      raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to find job: #{id}"
+    def index(**opts)
+      cmd = FlightJobScriptAPI::SystemCommand.flight_list_jobs(**opts).tap do |cmd|
+        next if cmd.exitstatus == 0
+        raise FlightJobScriptAPI::CommandError, 'Unexpectedly failed to list jobs'
+      end
+      JSON.parse(cmd.stdout).map do |metadata|
+        new(user: opts[:user], **metadata)
+      end
     end
 
-    new(user: opts[:user], **JSON.parse(cmd.stdout))
+    def find(id, **opts)
+      cmd = FlightJobScriptAPI::SystemCommand.flight_info_job(id, **opts).tap do |cmd|
+        next if cmd.exitstatus == 0
+        return nil if cmd.exitstatus == 23
+        raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to find job: #{id}"
+      end
+
+      new(user: opts[:user], **JSON.parse(cmd.stdout))
+    end
   end
 
   attr_reader :metadata, :user

--- a/api/app/models/script.rb
+++ b/api/app/models/script.rb
@@ -41,6 +41,12 @@ class Script
     end
 
     def find(id, **opts)
+      find!(id, **opts)
+    rescue FlightJobScriptAPI::CommandError
+      nil
+    end
+
+    def find!(id, **opts)
       cmd = FlightJobScriptAPI::SystemCommand.flight_info_script(id, **opts).tap do |cmd|
         next if cmd.exitstatus == 0
         return nil if cmd.exitstatus == 22

--- a/api/app/models/template.rb
+++ b/api/app/models/template.rb
@@ -27,32 +27,36 @@
 #==============================================================================
 
 class Template
-  def self.index(**opts)
-    cmd = FlightJobScriptAPI::SystemCommand.flight_list_templates(**opts).tap do |cmd|
-      next if cmd.exitstatus == 0
-      raise FlightJobScriptAPI::CommandError, 'Unexpectedly failed to list templates'
-    end
-    JSON.parse(cmd.stdout).map do |metadata|
-      new(**metadata)
-    end
-  end
+  class << self
+    prepend FlightJobScriptAPI::ModelCache
 
-  def self.find(id, **opts)
-    # The underlying CLI has supports non-deterministic indexing of templates
-    # This "okay" in the CLI but makes the API unnecessarily complicated
-    # Instead, all "ids" which match an integer will be ignored
-    # NOTE: This means templates which are named after an integer may be indexed
-    #       but can't be found. However this is an odd edge case and is currently
-    #       being ignored
-    return if /\A\d+\Z/.match?(id)
-
-    cmd = FlightJobScriptAPI::SystemCommand.flight_info_template(id, **opts).tap do |cmd|
-      next if cmd.exitstatus == 0
-      return nil if cmd.exitstatus == 21
-      raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to find template: #{id}"
+    def index(**opts)
+      cmd = FlightJobScriptAPI::SystemCommand.flight_list_templates(**opts).tap do |cmd|
+        next if cmd.exitstatus == 0
+        raise FlightJobScriptAPI::CommandError, 'Unexpectedly failed to list templates'
+      end
+      JSON.parse(cmd.stdout).map do |metadata|
+        new(**metadata)
+      end
     end
 
-    new(**JSON.parse(cmd.stdout))
+    def find(id, **opts)
+      # The underlying CLI has supports non-deterministic indexing of templates
+      # This "okay" in the CLI but makes the API unnecessarily complicated
+      # Instead, all "ids" which match an integer will be ignored
+      # NOTE: This means templates which are named after an integer may be indexed
+      #       but can't be found. However this is an odd edge case and is currently
+      #       being ignored
+      return if /\A\d+\Z/.match?(id)
+
+      cmd = FlightJobScriptAPI::SystemCommand.flight_info_template(id, **opts).tap do |cmd|
+        next if cmd.exitstatus == 0
+        return nil if cmd.exitstatus == 21
+        raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to find template: #{id}"
+      end
+
+      new(**JSON.parse(cmd.stdout))
+    end
   end
 
   attr_reader :metadata

--- a/api/app/models/template.rb
+++ b/api/app/models/template.rb
@@ -41,6 +41,12 @@ class Template
     end
 
     def find(id, **opts)
+      find!(id, **opts)
+    rescue FlightJobScriptAPI::CommandError
+      nil
+    end
+
+    def find!(id, **opts)
       # The underlying CLI has supports non-deterministic indexing of templates
       # This "okay" in the CLI but makes the API unnecessarily complicated
       # Instead, all "ids" which match an integer will be ignored

--- a/api/config.ru
+++ b/api/config.ru
@@ -39,6 +39,7 @@ end
 
 v = FlightJobScriptAPI::Configuration::API_VERSION
 app = Rack::Builder.new do
+  use RequestStore::Middleware
   map("/#{v}/render") { run RenderApp }
   map("/#{v}") { run App }
 end

--- a/api/lib/flight_job_script_api.rb
+++ b/api/lib/flight_job_script_api.rb
@@ -28,6 +28,7 @@
 
 module FlightJobScriptAPI
   autoload(:Configuration, 'flight_job_script_api/configuration')
+  autoload(:ModelCache, 'flight_job_script_api/model_cache')
   autoload(:SystemCommand, 'flight_job_script_api/system_command')
 
   class UnexpectedError < StandardError; end

--- a/api/lib/flight_job_script_api/model_cache.rb
+++ b/api/lib/flight_job_script_api/model_cache.rb
@@ -35,7 +35,7 @@ module FlightJobScriptAPI::ModelCache
     end
   end
 
-  def find(id, **opts)
+  def find!(id, **opts)
     record = get_from_cache(id)
     return record unless record.nil?
     super.tap do |record|

--- a/client/src/JobsTable.js
+++ b/client/src/JobsTable.js
@@ -2,8 +2,9 @@ import React from 'react';
 import TimeAgo from 'react-timeago';
 import { Badge, Table } from 'reactstrap';
 import { Link, useHistory } from 'react-router-dom';
-import { useTable, useSortBy } from 'react-table';
+import { useTable, usePagination, useSortBy } from 'react-table';
 
+import PaginationControls from './PaginationControls';
 import styles from './JobsTable.module.css';
 import { stateColourMap } from './utils';
 
@@ -64,16 +65,40 @@ function JobsTable({ reloadJobs, jobs }) {
   const initialState = {
     sortBy: [{ id: 'attributes.createdAt', desc: true }],
   };
-  const tableInstance = useTable({ columns, data, initialState }, useSortBy)
+  const tableInstance = useTable({ columns, data, initialState }, useSortBy, usePagination)
   const {
     getTableProps,
     getTableBodyProps,
     headerGroups,
-    rows,
+    page,
     prepareRow,
+
+    // Pagination functionality.
+    canPreviousPage,
+    canNextPage,
+    pageCount,
+    gotoPage,
+    nextPage,
+    previousPage,
+    state: { pageIndex },
+
   } = tableInstance
 
+  const paginationControls = (
+    <PaginationControls
+      canNextPage={canNextPage}
+      canPreviousPage={canPreviousPage}
+      gotoPage={gotoPage}
+      nextPage={nextPage}
+      pageIndex={pageIndex}
+      pageCount={pageCount}
+      previousPage={previousPage}
+    />
+  );
+
   return (
+    <>
+    {paginationControls}
     <Table
       {...getTableProps()}
       bordered
@@ -90,7 +115,7 @@ function JobsTable({ reloadJobs, jobs }) {
       </thead>
       <tbody {...getTableBodyProps()}>
         {
-          rows.map(row => (
+          page.map(row => (
             <TableRow
               key={row.original.id}
               prepareRow={prepareRow}
@@ -101,6 +126,8 @@ function JobsTable({ reloadJobs, jobs }) {
         }
       </tbody>
     </Table>
+    {paginationControls}
+    </>
   );
 }
 

--- a/client/src/PaginationControls.js
+++ b/client/src/PaginationControls.js
@@ -1,0 +1,70 @@
+import { Pagination, PaginationItem, PaginationLink } from 'reactstrap';
+
+function PaginationControls({
+  canNextPage,
+  canPreviousPage,
+  gotoPage,
+  nextPage,
+  pageIndex,
+  previousPage,
+  pageCount,
+}) {
+  const namedLinkOffsets = [-2, -1, 0, 1, 2];
+  const namedLinks = namedLinkOffsets
+    .map(offset => pageIndex + offset)
+    .filter(idx => idx >= 0 && idx <= pageCount - 1)
+    .map(idx => (
+      <PaginationItem active={idx === pageIndex} >
+        <PaginationLink onClick={() => gotoPage(idx)}>
+          {idx + 1}
+        </PaginationLink>
+      </PaginationItem>
+    ));
+  const preDots = pageIndex + namedLinkOffsets[0] > 0 ?
+    (
+      <PaginationItem disabled >
+        <PaginationLink>&hellip;</PaginationLink>
+      </PaginationItem>
+    ) : null;
+  const postDots = pageIndex + namedLinkOffsets[namedLinkOffsets.length - 1] < pageCount - 1 ?
+    (
+      <PaginationItem disabled >
+        <PaginationLink>&hellip;</PaginationLink>
+      </PaginationItem>
+    ) : null;
+
+
+  return (
+    <Pagination aria-label="Page navigation example">
+      <PaginationItem disabled={!canPreviousPage}>
+        <PaginationLink
+          first
+          onClick={() => gotoPage(0)}
+        />
+      </PaginationItem>
+      <PaginationItem disabled={!canPreviousPage}>
+        <PaginationLink
+          previous
+          onClick={() => previousPage()}
+        />
+      </PaginationItem>
+      {preDots}
+      {namedLinks}
+      {postDots}
+      <PaginationItem disabled={!canNextPage}>
+        <PaginationLink
+          next
+          onClick={() => nextPage()}
+        />
+      </PaginationItem>
+      <PaginationItem disabled={!canNextPage}>
+        <PaginationLink
+          last
+          onClick={() => gotoPage(pageCount - 1)}
+        />
+      </PaginationItem>
+    </Pagination>
+  );
+}
+
+export default PaginationControls;

--- a/client/src/QuestionSet.js
+++ b/client/src/QuestionSet.js
@@ -245,10 +245,15 @@ function SaveButton({ answers, className, state, templateId }) {
   const { loading, post, response } = useGenerateScript(templateId, flattenedAnswers);
 
   const submit = async () => {
-    await post()
-    if (response.ok) {
-      history.push('/scripts');
-    } else {
+    try {
+      await post();
+      if (response.ok) {
+        const script = ( await response.json() ).data;
+        history.push(`/scripts/${script.id}`);
+      } else {
+        throw new Error();
+      }
+    } catch (e) {
       addToast({
         body: (
           <div>

--- a/client/src/ScriptsTable.js
+++ b/client/src/ScriptsTable.js
@@ -2,9 +2,10 @@ import React from 'react';
 import TimeAgo from 'react-timeago';
 import { ButtonToolbar, Table } from 'reactstrap';
 import { Link, useHistory } from "react-router-dom";
-import { useTable, useSortBy } from 'react-table';
+import { useTable, usePagination, useSortBy } from 'react-table';
 
 import DeleteScriptButton from './DeleteScriptButton';
+import PaginationControls from './PaginationControls';
 import SubmitScriptButton from './SubmitScriptButton';
 import styles from './ScriptsTable.module.css';
 
@@ -55,16 +56,40 @@ function ScriptsTable({ reloadScripts, scripts }) {
   const initialState = {
     sortBy: [{ id: 'attributes.createdAt', desc: true }],
   };
-  const tableInstance = useTable({ columns, data, initialState }, useSortBy)
+  const tableInstance = useTable({ columns, data, initialState }, useSortBy, usePagination)
   const {
     getTableProps,
     getTableBodyProps,
     headerGroups,
-    rows,
+    page,
     prepareRow,
+
+    // Pagination functionality.
+    canPreviousPage,
+    canNextPage,
+    pageCount,
+    gotoPage,
+    nextPage,
+    previousPage,
+    state: { pageIndex },
+
   } = tableInstance
 
+  const paginationControls = (
+    <PaginationControls
+      canNextPage={canNextPage}
+      canPreviousPage={canPreviousPage}
+      gotoPage={gotoPage}
+      nextPage={nextPage}
+      pageIndex={pageIndex}
+      pageCount={pageCount}
+      previousPage={previousPage}
+    />
+  );
+
   return (
+    <>
+    {paginationControls}
     <Table
       {...getTableProps()}
       bordered
@@ -81,7 +106,7 @@ function ScriptsTable({ reloadScripts, scripts }) {
       </thead>
       <tbody {...getTableBodyProps()}>
         {
-          rows.map(row => (
+          page.map(row => (
             <TableRow
               key={row.original.id}
               prepareRow={prepareRow}
@@ -92,6 +117,8 @@ function ScriptsTable({ reloadScripts, scripts }) {
         }
       </tbody>
     </Table>
+    {paginationControls}
+    </>
   );
 }
 

--- a/client/src/TemplatesPage.js
+++ b/client/src/TemplatesPage.js
@@ -37,7 +37,7 @@ function TemplatesPage() {
             </OverlayContainer>
           )
         }
-        { <TemplateCardDeck templates={templates || []} /> }
+        <TemplateCardDeck templates={templates || []} />
       </React.Fragment>
     );
   }


### PR DESCRIPTION
The first pass at performance improvements.

Including related resources on the script and job index pages resulted in `O(N)` calls to `flight job` where `N` is the number of scripts / jobs respectively.  This has now been reduced to `O(1)` calls.  The mechanism is to introduce a per-request cache for loaded templates, scripts and jobs.  When a resource is requested, the cache is checked first and only if it is not present in the cache is a call to `flight job` made.  The cache is also primed to include any related resources requested prior to listing the requested resources.

With those changes the page load times have changed from:

* script listing page with 20 scripts: 23 seconds
* job listing page with 100 jobs: Gateway timeout
* script show page: 2.25 seconds
* job show page: 2.25 seconds

to

* script listing page with 20 scripts: 1.5 seconds
* job listing page with 100 jobs: 1.8 seconds
* script show page: 1.8 seconds
* job show page: 1.7 seconds

### Additional changes made

The client also redirects correctly after creating a script.  This is mostly a UX fix, but does result in some performance benefit.

The script and job tables are now paginated.  The entire data is requested up-front, but only the first 10 rows are rendred into the page.  Again, this is mostly a UX fix, but does result in fewer DOM operations so will have a small performance improvement.

The `{Template,Script,Job}.find` method has also changed so that it no longer throws an exception should there be an unexpected error when loading a Template/Script/Job.  A `find!` method has been added which provides the previous behaviour.
