### PR TITLE
Add routes to for the script content and notes

### DIFF
--- a/api/app.rb
+++ b/api/app.rb
@@ -146,6 +146,14 @@ class App < Sinatra::Base
     show
 
     destroy { resource.delete(user: current_user) }
+
+    has_one :note do
+      pluck { resource.find_note }
+    end
+
+    has_one :content do
+      pluck { resource.find_content }
+    end
   end
 
   resource :jobs, pkre: /[\w-]+/ do

--- a/api/app.rb
+++ b/api/app.rb
@@ -163,7 +163,7 @@ class App < Sinatra::Base
     end
   end
 
-  resource :script_notes, pkre: /[\w-]+/ do
+  resource :notes, pkre: /[\w-]+/ do
     helpers do
       def find(id)
         ScriptNote.find(id, user: current_user)

--- a/api/app.rb
+++ b/api/app.rb
@@ -274,6 +274,11 @@ class RenderApp < Sinatra::Base
       status 201
       next JSONAPI::Serializer.serialize(script).to_json
 
+    # The script name/id has already been taken
+    elsif cmd.exitstatus == 7
+      status 409
+      halt
+
     # Technically this should not be reached as it means the template does not exist
     elsif cmd.exitstatus == 21
       status 404

--- a/api/app.rb
+++ b/api/app.rb
@@ -279,6 +279,11 @@ class RenderApp < Sinatra::Base
       status 409
       halt
 
+    # Return the error message for invalid inputs
+    elsif cmd.exitstatus == 3
+      status 422
+      halt cmd.stderr.split(':', 2)[1]
+
     # Technically this should not be reached as it means the template does not exist
     elsif cmd.exitstatus == 21
       status 404

--- a/api/app.rb
+++ b/api/app.rb
@@ -255,8 +255,14 @@ class RenderApp < Sinatra::Base
 
   # TODO: The :id should be parsed against the same regex as above
   post '/:id' do
-    answers = params.to_json
-    cmd = FlightJobScriptAPI::SystemCommand.flight_create_script(params[:id], user: @current_user, stdin: answers)
+    hash = params.to_h.dup
+    # Ensure name is a string and treat nil/empty-string as the same input
+    # NOTE: This prevents a question from using the 'name' key
+    #       Consider refactoring to be a standard JSON:API route
+    name = hash.delete('name').to_s
+    name = nil if name.empty?
+    answers = hash.to_json
+    cmd = FlightJobScriptAPI::SystemCommand.flight_create_script(params[:id], name, user: @current_user, stdin: answers)
 
     if cmd.exitstatus == 0
       response.headers['Content-Type'] = 'application/vnd.api+json'

--- a/api/app.rb
+++ b/api/app.rb
@@ -145,7 +145,14 @@ class App < Sinatra::Base
 
     show
 
-    destroy { resource.delete(user: current_user) }
+    update do |attr|
+      if attr.key?(:name)
+        resource.rename(attr[:name])
+      end
+      resource
+    end
+
+    destroy { resource.delete }
 
     has_one :note do
       pluck { resource.find_note }

--- a/api/app.rb
+++ b/api/app.rb
@@ -263,13 +263,17 @@ class RenderApp < Sinatra::Base
   # TODO: The :id should be parsed against the same regex as above
   post '/:id' do
     hash = params.to_h.dup
-    # Ensure name is a string and treat nil/empty-string as the same input
-    # NOTE: This prevents a question from using the 'name' key
+    # Ensure name and notes are stringss and treat nil/empty-string as the same input
+    # NOTE: This prevents a question from using the 'name'/'notes' keys
     #       Consider refactoring to be a standard JSON:API route
     name = hash.delete('name').to_s
     name = nil if name.empty?
+    notes = hash.delete('notes').to_s
+    notes = nil if notes.empty?
     answers = hash.to_json
-    cmd = FlightJobScriptAPI::SystemCommand.flight_create_script(params[:id], name, user: @current_user, stdin: answers)
+    cmd = FlightJobScriptAPI::SystemCommand.flight_create_script(
+      params[:id], name, notes: notes, answers: answers, user: @current_user
+    )
 
     if cmd.exitstatus == 0
       response.headers['Content-Type'] = 'application/vnd.api+json'

--- a/api/app.rb
+++ b/api/app.rb
@@ -156,6 +156,21 @@ class App < Sinatra::Base
     end
   end
 
+  resource :script_notes, pkre: /[\w-]+/ do
+    helpers do
+      def find(id)
+        ScriptNote.find(id, user: current_user)
+      end
+    end
+
+    show
+
+    update do |attr|
+      resource.save_payload(attr[:payload])
+      resource
+    end
+  end
+
   resource :jobs, pkre: /[\w-]+/ do
     helpers do
       def find(id)

--- a/api/app.rb
+++ b/api/app.rb
@@ -145,13 +145,6 @@ class App < Sinatra::Base
 
     show
 
-    update do |attr|
-      if attr.key?(:name)
-        resource.rename(attr[:name])
-      end
-      resource
-    end
-
     destroy { resource.delete }
 
     has_one :note do

--- a/api/app/models/script.rb
+++ b/api/app/models/script.rb
@@ -68,7 +68,7 @@ class Script
   end
 
   def id
-    metadata['id']
+    metadata['internal_id']
   end
 
   def template

--- a/api/app/models/script.rb
+++ b/api/app/models/script.rb
@@ -80,17 +80,6 @@ class Script
     @template
   end
 
-  def rename(name)
-    FlightJobScriptAPI::SystemCommand.flight_rename_script(id, name, user: user).tap do |cmd|
-      if cmd.exitstatus == 0
-        @metadata = JSON.parse(cmd.stdout)
-      # TODO: Detect name conflicts and raise 422
-      else
-        raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to rename script: #{id}"
-      end
-    end
-  end
-
   def delete
     FlightJobScriptAPI::SystemCommand.flight_delete_script(id, user: user).tap do |cmd|
       next if cmd.exitstatus == 0

--- a/api/app/models/script.rb
+++ b/api/app/models/script.rb
@@ -68,7 +68,7 @@ class Script
   end
 
   def id
-    metadata['internal_id']
+    metadata['id']
   end
 
   def template

--- a/api/app/models/script.rb
+++ b/api/app/models/script.rb
@@ -80,8 +80,19 @@ class Script
     @template
   end
 
-  def delete(**opts)
-    FlightJobScriptAPI::SystemCommand.flight_delete_script(id, **opts).tap do |cmd|
+  def rename(name)
+    FlightJobScriptAPI::SystemCommand.flight_rename_script(id, name, user: user).tap do |cmd|
+      if cmd.exitstatus == 0
+        @metadata = JSON.parse(cmd.stdout)
+      # TODO: Detect name conflicts and raise 422
+      else
+        raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to rename script: #{id}"
+      end
+    end
+  end
+
+  def delete
+    FlightJobScriptAPI::SystemCommand.flight_delete_script(id, user: user).tap do |cmd|
       next if cmd.exitstatus == 0
       raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to delete script: #{id}"
     end

--- a/api/app/models/script.rb
+++ b/api/app/models/script.rb
@@ -86,4 +86,12 @@ class Script
       raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to delete script: #{id}"
     end
   end
+
+  def find_content
+    ScriptContent.find(id, user: user)
+  end
+
+  def find_note
+    ScriptNote.find(id, user: user)
+  end
 end

--- a/api/app/models/script_content.rb
+++ b/api/app/models/script_content.rb
@@ -1,8 +1,7 @@
-# frozen_string_literal: true
 #==============================================================================
 # Copyright (C) 2021-present Alces Flight Ltd.
 #
-# This file is part of Flight Job Script Service.
+# This file is part of Flight Job.
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 # terms made available by Alces Flight Ltd - please direct inquiries
 # about licensing to licensing@alces-flight.com.
 #
-# Flight Job Script Service is distributed in the hope that it will be useful, but
+# Flight Job is distributed in the hope that it will be useful, but
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
 # IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
 # OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
@@ -18,18 +17,34 @@
 # details.
 #
 # You should have received a copy of the Eclipse Public License 2.0
-# along with Flight Job Script Service. If not, see:
+# along with Flight Job. If not, see:
 #
 #  https://opensource.org/licenses/EPL-2.0
 #
-# For more information on Flight Job Script Service, please visit:
-# https://github.com/openflighthpc/flight-job-script-service
+# For more information on Flight Job, please visit:
+# https://github.com/openflighthpc/flight-job
 #==============================================================================
 
-class ScriptSerializer < ApplicationSerializer
-  attribute(:path) { object.metadata['path'] }
-  attribute(:name) { object.metadata['script_name'] }
-  attribute(:created_at) { object.metadata['created_at'] }
+class ScriptContent
+  class << self
+    prepend FlightJobScriptAPI::ModelCache
 
-  has_one(:template)
+    def find(script_id, **opts)
+      new Script.find(script_id, **opts)
+    end
+  end
+
+  attr_reader :script
+
+  def initialize(script)
+    @script = script
+  end
+
+  def id
+    script.id
+  end
+
+  def payload
+    @payload ||= File.read(script.metadata['path'])
+  end
 end

--- a/api/app/models/script_note.rb
+++ b/api/app/models/script_note.rb
@@ -43,6 +43,18 @@ class ScriptNote
   end
 
   def payload
-    @payload ||= script.metadata['notes']
+    script.metadata['notes']
+  end
+
+  def save_payload(content)
+    FlightJobScriptAPI::SystemCommand.flight_edit_script_notes(
+      id, user: script.user, stdin: content
+    ).tap do |cmd|
+      next if cmd.exitstatus == 0
+      raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to update script notes: #{id}"
+    end
+    # Update the script's metadata in case it has been cached
+    # XXX: Should the cache be flagged as dirty instead?
+    script.metadata['notes'] = content
   end
 end

--- a/api/app/models/script_note.rb
+++ b/api/app/models/script_note.rb
@@ -1,8 +1,7 @@
-# frozen_string_literal: true
 #==============================================================================
 # Copyright (C) 2021-present Alces Flight Ltd.
 #
-# This file is part of Flight Job Script Service.
+# This file is part of Flight Job.
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 # terms made available by Alces Flight Ltd - please direct inquiries
 # about licensing to licensing@alces-flight.com.
 #
-# Flight Job Script Service is distributed in the hope that it will be useful, but
+# Flight Job is distributed in the hope that it will be useful, but
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
 # IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
 # OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
@@ -18,18 +17,32 @@
 # details.
 #
 # You should have received a copy of the Eclipse Public License 2.0
-# along with Flight Job Script Service. If not, see:
+# along with Flight Job. If not, see:
 #
 #  https://opensource.org/licenses/EPL-2.0
 #
-# For more information on Flight Job Script Service, please visit:
-# https://github.com/openflighthpc/flight-job-script-service
+# For more information on Flight Job, please visit:
+# https://github.com/openflighthpc/flight-job
 #==============================================================================
 
-class ScriptSerializer < ApplicationSerializer
-  attribute(:path) { object.metadata['path'] }
-  attribute(:name) { object.metadata['script_name'] }
-  attribute(:created_at) { object.metadata['created_at'] }
+class ScriptNote
+  class << self
+    def find(script_id, **opts)
+      new Script.find(script_id, **opts)
+    end
+  end
 
-  has_one(:template)
+  attr_reader :script
+
+  def initialize(script)
+    @script = script
+  end
+
+  def id
+    script.id
+  end
+
+  def payload
+    @payload ||= script.metadata['notes']
+  end
 end

--- a/api/app/models/script_note.rb
+++ b/api/app/models/script_note.rb
@@ -28,7 +28,8 @@
 class ScriptNote
   class << self
     def find(script_id, **opts)
-      new Script.find(script_id, **opts)
+      script = Script.find(script_id, **opts)
+      script ? new(script) : nil
     end
   end
 

--- a/api/app/serializers/script_content_serializer.rb
+++ b/api/app/serializers/script_content_serializer.rb
@@ -26,10 +26,8 @@
 # https://github.com/openflighthpc/flight-job-script-service
 #==============================================================================
 
-class ScriptSerializer < ApplicationSerializer
-  attribute(:path) { object.metadata['path'] }
-  attribute(:name) { object.metadata['script_name'] }
-  attribute(:created_at) { object.metadata['created_at'] }
+class ScriptContentSerializer < ApplicationSerializer
+  attributes(:payload)
 
-  has_one(:template)
+  has_one :script
 end

--- a/api/app/serializers/script_content_serializer.rb
+++ b/api/app/serializers/script_content_serializer.rb
@@ -27,6 +27,10 @@
 #==============================================================================
 
 class ScriptContentSerializer < ApplicationSerializer
+  def type
+    'contents'
+  end
+
   attributes(:payload)
 
   has_one :script

--- a/api/app/serializers/script_note_serializer.rb
+++ b/api/app/serializers/script_note_serializer.rb
@@ -27,6 +27,10 @@
 #==============================================================================
 
 class ScriptNoteSerializer < ApplicationSerializer
+  def type
+    'notes'
+  end
+
   attributes(:payload)
 
   has_one :script

--- a/api/app/serializers/script_note_serializer.rb
+++ b/api/app/serializers/script_note_serializer.rb
@@ -26,10 +26,8 @@
 # https://github.com/openflighthpc/flight-job-script-service
 #==============================================================================
 
-class ScriptSerializer < ApplicationSerializer
-  attribute(:path) { object.metadata['path'] }
-  attribute(:name) { object.metadata['script_name'] }
-  attribute(:created_at) { object.metadata['created_at'] }
+class ScriptNoteSerializer < ApplicationSerializer
+  attributes(:payload)
 
-  has_one(:template)
+  has_one :script
 end

--- a/api/app/serializers/script_serializer.rb
+++ b/api/app/serializers/script_serializer.rb
@@ -30,7 +30,7 @@ class ScriptSerializer < ApplicationSerializer
   attribute(:path) { object.metadata['path'] }
   attribute(:created_at) { object.metadata['created_at'] }
 
-  attribute(:name) { object.metadata['public_id'] }
+  attribute(:name) { object.metadata['script_name'] }
 
   has_one(:template)
 end

--- a/api/app/serializers/script_serializer.rb
+++ b/api/app/serializers/script_serializer.rb
@@ -30,7 +30,7 @@ class ScriptSerializer < ApplicationSerializer
   attribute(:path) { object.metadata['path'] }
   attribute(:created_at) { object.metadata['created_at'] }
 
-  attribute(:name) { object.metadata['script_name'] }
+  attribute(:name) { object.id }
 
   has_one(:template)
 end

--- a/api/app/serializers/script_serializer.rb
+++ b/api/app/serializers/script_serializer.rb
@@ -28,8 +28,9 @@
 
 class ScriptSerializer < ApplicationSerializer
   attribute(:path) { object.metadata['path'] }
-  attribute(:name) { object.metadata['script_name'] }
   attribute(:created_at) { object.metadata['created_at'] }
+
+  attribute(:name) { object.metadata['public_id'] }
 
   has_one(:template)
 end

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -371,36 +371,6 @@ Content-Type: application/vnd.api+json
 }
 ```
 
-## PATCH - /scripts/:id
-
-Update the `name` attribute for the given script
-
-```
-PATCH /v0/scripts/:id
-Authorization: basic <base64 username:password>
-Accept: application/vnd.api+json
-{
-  "data": {
-    "type": "scripts",
-    "id": STRING,
-    "attributes": {
-      "name": STRING    # RECOMMENDED: # The new script name
-    }
-  }
-}
-
-HTTP/2 200 OK
-Content-Type: application/vnd.api+json
-{
-  "data": ScriptResource,
-  "jsonapi": {
-    "version": "1.0"
-  },
-  "included": [
-  ]
-}
-```
-
 ## GET - /scripts/:id/content
 
 Return the `content` of the given `script`.

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -609,6 +609,8 @@ The provided keys SHOULD match the `question_ids` associated with the related `t
 
 *WARNING:* Reserved keys will not be provided as `answers`, which may create a conflict with `questions_ids`. Additional reserved keys maybe added in a minor release, notwithstanding the conflicts they may create.
 
+The `name` MUST be unique otherwise the request SHALL return 409 Conflict.
+
 Due to the underlining templating engine, this route could fail to render for various reasons including but not limited to:
 1. The client not sending all the required keys, or
 2. The template being misconfigured.
@@ -633,6 +635,16 @@ Content-Type: application/vnd.api+json
   "data": ScriptResource,
 }
 
+# With a duplicate "name"
+POST /v0/render/:template_id
+Authorization: Bearer <jwt>
+Content-Type: application/json
+Accept: application/vnd.api+json
+{
+  "name": "existing-name"
+}
+
+HTTP/2 409 Conflict
 
 # With invalid credentials
 POST /v0/render/:template_id

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -270,7 +270,7 @@ Content-Type: application/vnd.api+json
     "type": "scripts",          # REQUIRED - Specfies the resource is a script
     "id": STRING,               # REQUIRED - The script's ID
     "attributes": {
-      "name": STRING,           # REQUIRED - The name of the script
+      "name": STRING,           # REQUIRED - Same as the ID
       "createdAt": STRING,      # REQUIRED - The creation date-time in RFC3339 format
       "path": STRING            # REQUIRED - The script's path on the filesystem
     },

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -150,7 +150,7 @@ Content-Type: application/vnd.api+json
 }
 ```
 
-## Get - /templates/:id/questions
+## GET - /templates/:id/questions
 
 Return all the `question` resources associated with the given `template` by `template_id`
 
@@ -270,7 +270,7 @@ Content-Type: application/vnd.api+json
     "type": "scripts",          # REQUIRED - Specfies the resource is a script
     "id": STRING,               # REQUIRED - The script's ID
     "attributes": {
-      "scriptName": STRING,     # REQUIRED - The name of the script
+      "name": STRING,           # REQUIRED - The name of the script
       "createdAt": STRING,      # REQUIRED - The creation date-time in RFC3339 format
       "path": STRING            # REQUIRED - The script's path on the filesystem
     },
@@ -371,6 +371,84 @@ Content-Type: application/vnd.api+json
 }
 ```
 
+## PATCH - /scripts/:id
+
+Update the `name` attribute for the given script
+
+```
+PATCH /v0/scripts/:id
+Authorization: basic <base64 username:password>
+Accept: application/vnd.api+json
+{
+  "data": {
+    "type": "scripts",
+    "id": STRING,
+    "attributes": {
+      "name": STRING    # RECOMMENDED: # The new script name
+    }
+  }
+}
+
+HTTP/2 200 OK
+Content-Type: application/vnd.api+json
+{
+  "data": ScriptResource,
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "included": [
+  ]
+}
+```
+
+## GET - /scripts/:id/content
+
+Return the `content` of the given `script`.
+
+```
+GET /v0/scripts/:id/content
+Authorization: basic <base64 username:password>
+Accept: application/vnd.api+json
+
+HTTP/2 200 OK
+Content-Type: application/vnd.api+json
+{
+  "data": {
+    "type": "contents",   # REQUIRED: Denotes the resource is a content
+    "id": STRING,         # REQUIRED: The ID of the related script
+    "attributes": {
+      "payload": STRING   # REQUIRED: The content of the script
+    }
+  },
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "included": [
+  ]
+}
+```
+
+## GET - /scripts/:id/note
+
+Return the `notes` about the given `script`.
+
+```
+GET /v0/scripts/:id/note
+Authorization: basic <base64 username:password>
+Accept: application/vnd.api+json
+
+HTTP/2 200 OK
+Content-Type: application/vnd.api+json
+{
+  "data": NoteResource,
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "included": [
+  ]
+}
+```
+
 ## DELETE - /scripts/:id
 
 Permanently remove a script
@@ -381,6 +459,63 @@ Authorization: Bearer <jwt>
 Accept: application/vnd.api+json
 
 HTTP/2 204 No Content
+```
+
+## GET - /notes/:id
+
+Return the `notes` about the given `script`.
+
+```
+GET /v0/scripts/:id/note
+Authorization: basic <base64 username:password>
+Accept: application/vnd.api+json
+
+HTTP/2 200 OK
+Content-Type: application/vnd.api+json
+{
+  "data": {
+    "type": "notes",      # REQUIRED: Denotes the resource is a note
+    "id": STRING,         # REQUIRED: The ID of the related script
+    "attributes": {
+      "payload": STRING   # REQUIRED: The note itself
+    }
+  },
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "included": [
+  ]
+}
+```
+
+## PATCH - /notes/:id
+
+Update the `note` about a `script`.
+
+```
+GET /v0/scripts/:id/note
+Authorization: basic <base64 username:password>
+Accept: application/vnd.api+json
+{
+  "data": {
+    "id": STRING,
+    "type": "notes",
+    "attributes": {
+      "payload": STRING   # RECOMMENDED: The updated note text
+    }
+  }
+}
+
+HTTP/2 200 OK
+Content-Type: application/vnd.api+json
+{
+  "data": NoteResource,
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "included": [
+  ]
+}
 ```
 
 ## GET - /jobs
@@ -496,6 +631,13 @@ Content-Type: application/vnd.api+json
 ## POST - /render/:template_id
 
 Renders the template against the provided date and saves it to the filesystem.
+
+The provided keys SHOULD match the `question_ids` associated with the related `template`. The following are OPTIONAL reserved keys which have special meanings:
+
+* `name`: Sets the `name` field on the `script`, and
+* `notes`: Creates the related `notes` resource with the provided text.
+
+*WARNING:* Reserved keys will not be provided as `answers`, which may create a conflict with `questions_ids`. Additional reserved keys maybe added in a minor release, notwithstanding the conflicts they may create.
 
 Due to the underlining templating engine, this route could fail to render for various reasons including but not limited to:
 1. The client not sending all the required keys, or

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -611,6 +611,14 @@ The provided keys SHOULD match the `question_ids` associated with the related `t
 
 The `name` MUST be unique otherwise the request SHALL return 409 Conflict.
 
+The `name` is subject to the following constraints:
+* It MUST start with an alphanumeric character,
+* It SHOULD be primarily alphanumeric characters but MAY contain hypen and underscore,
+* It MUST NOT use any other characters, and
+* It SHOULD be less than 16 characters (depending on the underlining CLI tools configuration).
+
+The response SHALL be 422 Unprocessable Entity if the above `name` constratins are not be met.
+
 Due to the underlining templating engine, this route could fail to render for various reasons including but not limited to:
 1. The client not sending all the required keys, or
 2. The template being misconfigured.

--- a/api/lib/flight_job_script_api/model_cache.rb
+++ b/api/lib/flight_job_script_api/model_cache.rb
@@ -45,12 +45,8 @@ module FlightJobScriptAPI::ModelCache
 
   private
 
-  # NOTE: Technically the 'id' is not globally unique for all models and
-  # depends on the user make the request. This is fine whilst the models are
-  # cached on a per-request basis, as they can only be a single user.
-  #
-  # However this assumption might fail if the cache is persisted across requests.
-  # Consider refactoring.
+  # NOTE: The 'id' is unique on a per user basis instead of globally. This works
+  #       as the RequestStore cache's 'per request' and thus is also 'per user'.
   def get_from_cache(id)
     cache_id = "#{self.name}:#{id}"
     RequestStore[cache_id]

--- a/api/lib/flight_job_script_api/model_cache.rb
+++ b/api/lib/flight_job_script_api/model_cache.rb
@@ -45,6 +45,12 @@ module FlightJobScriptAPI::ModelCache
 
   private
 
+  # NOTE: Technically the 'id' is not globally unique for all models and
+  # depends on the user make the request. This is fine whilst the models are
+  # cached on a per-request basis, as they can only be a single user.
+  #
+  # However this assumption might fail if the cache is persisted across requests.
+  # Consider refactoring.
   def get_from_cache(id)
     cache_id = "#{self.name}:#{id}"
     RequestStore[cache_id]

--- a/api/lib/flight_job_script_api/system_command.rb
+++ b/api/lib/flight_job_script_api/system_command.rb
@@ -55,8 +55,9 @@ module FlightJobScriptAPI
       new(*FlightJobScriptAPI.config.flight_job, 'info-script', id, '--json', '--internal-script-id', **opts).tap(&:wait)
     end
 
-    def self.flight_create_script(template_id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'create-script', template_id, '--json', '--answers', '@-', **opts).tap(&:wait)
+    def self.flight_create_script(template_id, name = nil, **opts)
+      args = name ? [template_id, name] : [template_id]
+      new(*FlightJobScriptAPI.config.flight_job, 'create-script', *args, '--json', '--answers', '@-', **opts).tap(&:wait)
     end
 
     def self.flight_edit_script_notes(script_id, **opts)

--- a/api/lib/flight_job_script_api/system_command.rb
+++ b/api/lib/flight_job_script_api/system_command.rb
@@ -54,7 +54,7 @@ module FlightJobScriptAPI
     end
 
     def self.flight_info_script(id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'info-script', id, '--json', '--internal-script-id', **opts).tap(&:run)
+      new(*FlightJobScriptAPI.config.flight_job, 'info-script', id, '--json', **opts).tap(&:run)
     end
 
     def self.flight_create_script(template_id, name = nil, answers: nil, notes: nil, **opts)
@@ -78,11 +78,11 @@ module FlightJobScriptAPI
     end
 
     def self.flight_edit_script_notes(script_id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'edit-script-notes', script_id, '--json', '--internal-script-id', '--notes', '@-', **opts).tap(&:run)
+      new(*FlightJobScriptAPI.config.flight_job, 'edit-script-notes', script_id, '--json', '--notes', '@-', **opts).tap(&:run)
     end
 
     def self.flight_delete_script(id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'delete-script', id, '--json', '--internal-script-id', **opts).tap(&:run)
+      new(*FlightJobScriptAPI.config.flight_job, 'delete-script', id, '--json',**opts).tap(&:run)
     end
 
     def self.flight_list_jobs(**opts)
@@ -94,7 +94,7 @@ module FlightJobScriptAPI
     end
 
     def self.flight_submit_job(script_id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'submit-job', script_id, '--json', '--internal-script-id', **opts).tap(&:run)
+      new(*FlightJobScriptAPI.config.flight_job, 'submit-job', script_id, '--json', **opts).tap(&:run)
     end
 
     attr_reader :cmd, :user, :mutex, :stdin

--- a/api/lib/flight_job_script_api/system_command.rb
+++ b/api/lib/flight_job_script_api/system_command.rb
@@ -52,7 +52,7 @@ module FlightJobScriptAPI
     end
 
     def self.flight_info_script(id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'info-script', id, '--json', **opts).tap(&:wait)
+      new(*FlightJobScriptAPI.config.flight_job, 'info-script', id, '--json', '--internal-script-id', **opts).tap(&:wait)
     end
 
     def self.flight_create_script(template_id, **opts)
@@ -60,11 +60,11 @@ module FlightJobScriptAPI
     end
 
     def self.flight_edit_script_notes(script_id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'edit-script-notes', script_id, '--json', '--notes', '@-', **opts).tap(&:wait)
+      new(*FlightJobScriptAPI.config.flight_job, 'edit-script-notes', script_id, '--json', '--internal-script-id', '--notes', '@-', **opts).tap(&:wait)
     end
 
     def self.flight_delete_script(id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'delete-script', id, '--json', **opts).tap(&:wait)
+      new(*FlightJobScriptAPI.config.flight_job, 'delete-script', id, '--json', '--internal-script-id', **opts).tap(&:wait)
     end
 
     def self.flight_list_jobs(**opts)
@@ -76,7 +76,7 @@ module FlightJobScriptAPI
     end
 
     def self.flight_submit_job(script_id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'submit-job', script_id, '--json', **opts).tap(&:wait)
+      new(*FlightJobScriptAPI.config.flight_job, 'submit-job', script_id, '--json', '--internal-script-id', **opts).tap(&:wait)
     end
 
     attr_reader :cmd, :user, :mutex, :stdin

--- a/api/lib/flight_job_script_api/system_command.rb
+++ b/api/lib/flight_job_script_api/system_command.rb
@@ -55,12 +55,16 @@ module FlightJobScriptAPI
       new(*FlightJobScriptAPI.config.flight_job, 'info-script', id, '--json', **opts).tap(&:wait)
     end
 
-    def self.flight_delete_script(id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'delete-script', id, '--json', **opts).tap(&:wait)
+    def self.flight_create_script(template_id, **opts)
+      new(*FlightJobScriptAPI.config.flight_job, 'create-script', template_id, '--json', '--answers', '@-', **opts).tap(&:wait)
     end
 
-    def self.flight_create_script(template_id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'create-script', template_id, '--json', '--stdin', **opts).tap(&:wait)
+    def self.flight_edit_script_notes(script_id, **opts)
+      new(*FlightJobScriptAPI.config.flight_job, 'edit-script-notes', script_id, '--json', '--notes', '@-', **opts).tap(&:wait)
+    end
+
+    def self.flight_delete_script(id, **opts)
+      new(*FlightJobScriptAPI.config.flight_job, 'delete-script', id, '--json', **opts).tap(&:wait)
     end
 
     def self.flight_list_jobs(**opts)

--- a/api/lib/flight_job_script_api/system_command.rb
+++ b/api/lib/flight_job_script_api/system_command.rb
@@ -64,6 +64,10 @@ module FlightJobScriptAPI
       new(*FlightJobScriptAPI.config.flight_job, 'edit-script-notes', script_id, '--json', '--internal-script-id', '--notes', '@-', **opts).tap(&:wait)
     end
 
+    def self.flight_rename_script(script_id, name, **opts)
+      new(*FlightJobScriptAPI.config.flight_job, 'rename-script', script_id, name, '--json', '--internal-script-id', **opts).tap(&:wait)
+    end
+
     def self.flight_delete_script(id, **opts)
       new(*FlightJobScriptAPI.config.flight_job, 'delete-script', id, '--json', '--internal-script-id', **opts).tap(&:wait)
     end

--- a/api/lib/flight_job_script_api/system_command.rb
+++ b/api/lib/flight_job_script_api/system_command.rb
@@ -81,10 +81,6 @@ module FlightJobScriptAPI
       new(*FlightJobScriptAPI.config.flight_job, 'edit-script-notes', script_id, '--json', '--internal-script-id', '--notes', '@-', **opts).tap(&:run)
     end
 
-    def self.flight_rename_script(script_id, name, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'rename-script', script_id, name, '--json', '--internal-script-id', **opts).tap(&:run)
-    end
-
     def self.flight_delete_script(id, **opts)
       new(*FlightJobScriptAPI.config.flight_job, 'delete-script', id, '--json', '--internal-script-id', **opts).tap(&:run)
     end


### PR DESCRIPTION
The following routes have been added:

* `GET /scripts/:id/note` - Return the `note` about the `script`
* `GET /scripts/:id/content` - Return the `content` of a `script`
* `GET /notes/:id` - Return the `note` for a `script` (as above)
* `PATCH /notes/:id` - Update the `note` for a `script`
* ~`PATCH /scripts/:id` - Update the `name` of a script`~

The `POST /render/:id` route has gained to reserved keys: `note` and `name`. These set the `note` and `name` fields/resource above. As a consequence, they can not be used as the `id` of a question. There is no validation on this, so the template render may silently fail.

NOTE: The API has been updated to make the script's `name` attribute the same as its `id`. Previously it was the "filename", which is already provided in the `path`. This should hopefully reduce the confusion between the `id`/`name` of a `script`.

---

~Future enhancement: Detect duplicate names~

~The underlining CLI does not currently provide the correct exit status if the `name` of a script is already taken. This can cause the ~`PATCH /scripts/:id` and~ `POST /render/:id` routes to fail with a `503`.~

~The underlining CLI should be updated to allow the API to return either `422` or `409`.~

The `/render/:template_id` route will return `409` Conflict if the script `name` is taken.

---

~Note about the script `name`:~

~Previously the script resource had a `name` field which corresponded to the "filename". This has been usurped to return the `public_id` of the underlining CLI data model. This change will cause legacy scripts `name` to default to their `id`. However all new scripts will receive a friendly `name` when they are created.~

~The `id` of the `script` now corresponds with the `internal_id` in the underlying data model.~

EDIT: The concept of an `internal_id` has been removed

EDIT: It is no longer possible to update the "name"/`id` of a script as:
* It has been removed from the underlying CLI tool, and
* Doing so would change the URL `id` and thus better suited to a `DELETE`/`POST` than a `PATCH`