### PR TITLE
Display script content and notes in webapp

### DIFF
--- a/api/app/serializers/script_serializer.rb
+++ b/api/app/serializers/script_serializer.rb
@@ -34,4 +34,5 @@ class ScriptSerializer < ApplicationSerializer
 
   has_one(:template)
   has_one(:note) { object.find_note }
+  has_one(:content) { object.find_content }
 end

--- a/api/app/serializers/script_serializer.rb
+++ b/api/app/serializers/script_serializer.rb
@@ -33,4 +33,5 @@ class ScriptSerializer < ApplicationSerializer
   attribute(:name) { object.id }
 
   has_one(:template)
+  has_one(:note) { object.find_note }
 end

--- a/client/bin/yarn-link-webapp-components.sh
+++ b/client/bin/yarn-link-webapp-components.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+CLIENT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"/..
+
+cd "${CLIENT_ROOT}"
+yarn link flight-webapp-components
+yarn link use-http
+yarn link react
+yarn link react-dom
+( cd "${CLIENT_ROOT}"/node_modules/react-dom && yarn link react )

--- a/client/bin/yarn-unlink-webapp-components.sh
+++ b/client/bin/yarn-unlink-webapp-components.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+CLIENT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"/..
+
+cd "${CLIENT_ROOT}"
+( cd "${CLIENT_ROOT}"/node_modules/react-dom && yarn unlink react )
+yarn unlink react-dom
+yarn unlink react
+yarn unlink use-http
+yarn unlink flight-webapp-components
+
+yarn install --check-files

--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
     "classnames": "^2.2.6",
     "debug": "^4.3.1",
     "flight-webapp-components": "git+https://github.com/openflighthpc/flight-webapp-components#0.1.4",
+    "highlight.js": "^10.7.2",
     "http-proxy-middleware": "^1.0.6",
     "react": "^17.0.1",
     "react-beforeunload": "^2.4.0",

--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
     "@testing-library/user-event": "^12.1.10",
     "classnames": "^2.2.6",
     "debug": "^4.3.1",
-    "flight-webapp-components": "git+https://github.com/openflighthpc/flight-webapp-components#0.1.4",
+    "flight-webapp-components": "git+https://github.com/openflighthpc/flight-webapp-components#0.1.5",
     "highlight.js": "^10.7.2",
     "http-proxy-middleware": "^1.0.6",
     "react": "^17.0.1",

--- a/client/src/DeleteScriptButton.js
+++ b/client/src/DeleteScriptButton.js
@@ -1,7 +1,6 @@
-import {
-  ConfirmedActionButton,
-  utils,
-} from 'flight-webapp-components';
+import classNames from 'classnames';
+import { Button } from 'reactstrap';
+import { ConfirmedActionButton, utils, } from 'flight-webapp-components';
 import { useDeleteScript } from './api';
 import { useToast } from './ToastContext';
 
@@ -52,6 +51,21 @@ function DeleteScriptButton({
     />
   );
 }
+
+function Disabled({ className }) {
+  return (
+    <Button
+      className={classNames(className)}
+      disabled
+      size="sm"
+    >
+      <i className={`fa fa-trash mr-1`}></i>
+      <span>Delete</span>
+    </Button>
+  );
+}
+
+DeleteScriptButton.Disabled = Disabled;
 
 function deleteFailedToast({ script, errorCode }) {
   let body = (

--- a/client/src/PaginationControls.js
+++ b/client/src/PaginationControls.js
@@ -14,7 +14,7 @@ function PaginationControls({
     .map(offset => pageIndex + offset)
     .filter(idx => idx >= 0 && idx <= pageCount - 1)
     .map(idx => (
-      <PaginationItem active={idx === pageIndex} >
+      <PaginationItem active={idx === pageIndex} key={idx} >
         <PaginationLink onClick={() => gotoPage(idx)}>
           {idx + 1}
         </PaginationLink>

--- a/client/src/ScriptActions.js
+++ b/client/src/ScriptActions.js
@@ -1,0 +1,50 @@
+import classNames from 'classnames';
+import { ButtonToolbar } from 'reactstrap';
+import { Link } from "react-router-dom";
+
+import DeleteScriptButton from './DeleteScriptButton';
+import SubmitScriptButton from './SubmitScriptButton';
+
+function ScriptActions({ className, includeLink=true, reloadScripts, script }) {
+  const link = (
+    <Link
+      className="btn btn-link btn-sm"
+      to={`/scripts/${script.id}`}
+    >
+      View script
+    </Link>
+  );
+
+  return (
+    <ButtonToolbar className={classNames(className)} >
+      { includeLink ? link : null }
+      <SubmitScriptButton
+        className="mr-2"
+        script={script}
+      />
+      <DeleteScriptButton
+        onDeleted={reloadScripts}
+        script={script}
+      />
+    </ButtonToolbar>
+  );
+}
+
+function DisabledActions({ className, includeLink=true }) {
+  const link = (
+    <Link className="btn btn-link btn-sm disabled">
+      View script
+    </Link>
+  );
+
+  return (
+    <ButtonToolbar className={classNames(className)} >
+      { includeLink ? link : null }
+      <SubmitScriptButton.Disabled className="mr-2" />
+      <DeleteScriptButton.Disabled />
+    </ButtonToolbar>
+  );
+}
+
+ScriptActions.Disabled = DisabledActions;
+export default ScriptActions;

--- a/client/src/ScriptCard.js
+++ b/client/src/ScriptCard.js
@@ -1,21 +1,28 @@
 import { Link } from 'react-router-dom';
 
-import DeleteScriptButton from './DeleteScriptButton';
 import MetadataEntry from './MetadataEntry';
-import SubmitScriptButton from './SubmitScriptButton';
+import ScriptActions from './ScriptActions';
 import TimeAgo from './TimeAgo';
-import { CardFooter } from './CardParts';
+import { RenderedNotesForScript } from './ScriptSummary';
 
-function ScriptCard({ reloadScripts, script }) {
+function ScriptMetadataCard({ reloadScripts, script }) {
   return (
-    <div className="card border-primary">
-      <h5
-        className="card-header ot-cevznel grkg-yvtug text-truncate"
-        title={script.attributes.name}
-      >
-        Script {script.attributes.name}
-      </h5>
-      <div className="card-body">
+    <div className="card">
+      <div className="card-header d-flex flex-row justify-content-between">
+        <h4
+          className="text-truncate mb-0"
+          title={script.attributes.name}
+        >
+          {script.attributes.name}
+        </h4>
+        <ScriptActions
+          className="h-100"
+          includeLink={false}
+          reloadScripts={reloadScripts}
+          script={script}
+        />
+      </div>
+      <div className="card-body d-flex flex-row flex-wrap">
         <dl>
           <MetadataEntry
             format={(value) => <code>{value}</code>}
@@ -48,18 +55,21 @@ function ScriptCard({ reloadScripts, script }) {
           />
         </dl>
       </div>
-      <CardFooter>
-        <div className="btn-toolbar justify-content-center">
-          <DeleteScriptButton
-            className="mr-2"
-            onDeleted={reloadScripts}
-            script={script}
-          />
-          <SubmitScriptButton script={script} />
-        </div>
-      </CardFooter>
     </div>
   );
 }
 
-export default ScriptCard;
+export function ScriptNotesCard({ script }) {
+  return (
+    <div className="card">
+      <h4 className="card-header">
+        Notes
+      </h4>
+      <div className="card-body">
+        <RenderedNotesForScript script={script} />
+      </div>
+    </div>
+  );
+}
+
+export default ScriptMetadataCard;

--- a/client/src/ScriptContentCard.js
+++ b/client/src/ScriptContentCard.js
@@ -1,8 +1,14 @@
+import 'highlight.js/styles/solarized-dark.css';
+import bash from 'highlight.js/lib/languages/bash';
 import classNames from 'classnames';
+import hljs from 'highlight.js/lib/core';
 import { DefaultErrorMessage, Spinner, utils } from 'flight-webapp-components';
+import { useEffect, useRef } from 'react';
 
 import styles from './JobCard.module.css';
 import {useFetchScriptContent} from './api';
+
+hljs.registerLanguage('bash', bash);
 
 function getContentFromResponse(data) {
   if (!utils.isObject(data)) { return null; }
@@ -46,11 +52,18 @@ export function RenderedAsyncContentForScript({ script }) {
 }
 
 export function RenderedContent({ content }) {
+  const contentRef = useRef(null);
+  useEffect(() => {
+    if (contentRef.current) {
+      hljs.highlightElement(contentRef.current, { language: 'bash' });
+    }
+  });
+
   if (content == null || content === "") {
     return <em>The selected script does not have any content.</em>;
   }
   return (
-    <pre className={styles.PreCode}><code>{content}</code></pre>
+    <pre className={styles.PreCode}><code ref={contentRef}>{content}</code></pre>
   );
 }
 

--- a/client/src/ScriptContentCard.js
+++ b/client/src/ScriptContentCard.js
@@ -1,0 +1,57 @@
+import classNames from 'classnames';
+import { DefaultErrorMessage, Spinner, utils } from 'flight-webapp-components';
+
+import styles from './JobCard.module.css';
+import {useFetchScriptContent} from './api';
+
+function getContentFromResponse(data) {
+  if (!utils.isObject(data)) { return null; }
+  if (!utils.isObject(data.data)) { return null; }
+  if (!utils.isObject(data.data.attributes)) { return null; }
+  return data.data.attributes.payload;
+}
+
+function ScriptContentCard({ className, script }) {
+  return (
+    <div className={classNames("card", className)} >
+      <div className="card-header d-flex flex-row justify-content-between">
+        <h4 className="mb-0">Content</h4>
+      </div>
+      <div className="card-body">
+        <RenderedContentForScript script={script} />
+      </div>
+    </div>
+  );
+}
+
+export function RenderedContentForScript({ script }) {
+  if (script.content == null) {
+    return <RenderedAsyncContentForScript script={script} />;
+  }
+
+
+  return <RenderedContent content={script.content.attributes.payload} />;
+}
+
+export function RenderedAsyncContentForScript({ script }) {
+  const { data, error, loading } = useFetchScriptContent(script);
+  if (loading) {
+    return <Spinner center="none" text="Loading script content..."/>;
+  }
+  if (error) {
+    return <DefaultErrorMessage />;
+  }
+
+  return <RenderedContent content={getContentFromResponse(data)} />;
+}
+
+export function RenderedContent({ content }) {
+  if (content == null || content === "") {
+    return <em>The selected script does not have any content.</em>;
+  }
+  return (
+    <pre className={styles.PreCode}><code>{content}</code></pre>
+  );
+}
+
+export default ScriptContentCard;

--- a/client/src/ScriptPage.js
+++ b/client/src/ScriptPage.js
@@ -7,6 +7,7 @@ import {
   Spinner,
 } from 'flight-webapp-components';
 
+import ScriptContentCard from './ScriptContentCard';
 import ScriptMetadataCard, { ScriptNotesCard } from './ScriptCard';
 import { useFetchScript } from './api';
 
@@ -25,10 +26,11 @@ function ScriptPage() {
     } else {
       return (
         <Row>
-          <Col>
+          <Col md={{ "size": 6 }}>
             <ScriptMetadataCard script={script} />
+            <ScriptContentCard className="mt-4" script={script} />
           </Col>
-          <Col>
+          <Col md={{ "size": 6 }}>
             <ScriptNotesCard script={script} />
           </Col>
         </Row>

--- a/client/src/ScriptPage.js
+++ b/client/src/ScriptPage.js
@@ -1,3 +1,4 @@
+import { Col, Row } from 'reactstrap';
 import { useParams } from 'react-router-dom';
 
 import {
@@ -6,7 +7,7 @@ import {
   Spinner,
 } from 'flight-webapp-components';
 
-import ScriptCard from './ScriptCard';
+import ScriptMetadataCard, { ScriptNotesCard } from './ScriptCard';
 import { useFetchScript } from './api';
 
 function ScriptPage() {
@@ -23,7 +24,14 @@ function ScriptPage() {
       return <DefaultErrorMessage />;
     } else {
       return (
-        <ScriptCard script={script} />
+        <Row>
+          <Col>
+            <ScriptMetadataCard script={script} />
+          </Col>
+          <Col>
+            <ScriptNotesCard script={script} />
+          </Col>
+        </Row>
       );
     }
   }

--- a/client/src/ScriptPage.js
+++ b/client/src/ScriptPage.js
@@ -26,11 +26,11 @@ function ScriptPage() {
     } else {
       return (
         <Row>
-          <Col md={{ "size": 6 }}>
+          <Col md={12} lg={6}>
             <ScriptMetadataCard script={script} />
             <ScriptContentCard className="mt-4" script={script} />
           </Col>
-          <Col md={{ "size": 6 }}>
+          <Col md={12} lg={6}>
             <ScriptNotesCard script={script} />
           </Col>
         </Row>

--- a/client/src/ScriptSummary.js
+++ b/client/src/ScriptSummary.js
@@ -1,0 +1,68 @@
+import ReactMarkdown from 'react-markdown'
+
+import { DefaultErrorMessage, Spinner, utils } from 'flight-webapp-components';
+
+import ScriptActions from './ScriptActions';
+import {useFetchScriptNotes} from './api';
+
+function getNoteFromResponse(data) {
+  if (!utils.isObject(data)) { return null; }
+  if (!utils.isObject(data.data)) { return null; }
+  if (!utils.isObject(data.data.attributes)) { return null; }
+  return data.data.attributes.payload;
+}
+
+function ScriptSummary({ reloadScripts, script }) {
+  const header = script == null ?
+    <h4 className="mb-0"> </h4> :
+    <h4 className="mb-0">{script.id}</h4>;
+  const actions = script == null ?
+    <ScriptActions.Disabled className="h-100" /> :
+    <ScriptActions
+      className="h-100"
+      reloadScripts={reloadScripts}
+      script={script}
+    />;
+
+  return (
+    <div className="card">
+      <div className="card-header d-flex flex-row justify-content-between">
+        {header}
+        {actions}
+      </div>
+      <div className="card-body">
+        {
+          script == null ?
+            "Select a script form the table to view its notes." :
+            <ScriptNotes script={script} />
+        }
+      </div>
+    </div>
+  );
+}
+
+export function ScriptNotes({ script }) {
+  const { data, error, loading } = useFetchScriptNotes(script);
+  if (loading) {
+    return <Spinner center="none" text="Loading script notes..."/>;
+  }
+  if (error) {
+    return <DefaultErrorMessage />;
+  }
+
+  let notes = getNoteFromResponse(data);
+  if (notes == null || notes === "") {
+    return <em>The selected script does not have any notes.</em>;
+  }
+  return <ReactMarkdown>{notes}</ReactMarkdown>;
+}
+
+export function ScriptNotesPlaceholder() {
+  return (
+    <div>
+      Select a script from the table to view its notes.
+    </div>
+  );
+};
+
+export default ScriptSummary;

--- a/client/src/ScriptSummary.js
+++ b/client/src/ScriptSummary.js
@@ -34,14 +34,22 @@ function ScriptSummary({ reloadScripts, script }) {
         {
           script == null ?
             "Select a script form the table to view its notes." :
-            <ScriptNotes script={script} />
+            <RenderedNotesForScript script={script} />
         }
       </div>
     </div>
   );
 }
 
-export function ScriptNotes({ script }) {
+export function RenderedNotesForScript({ script }) {
+  if (script.note == null) {
+    return <RenderedAsyncNotesForScript script={script} />;
+  }
+
+  return <RenderedNotes notes={script.note.attributes.payload} />;
+}
+
+export function RenderedAsyncNotesForScript({ script }) {
   const { data, error, loading } = useFetchScriptNotes(script);
   if (loading) {
     return <Spinner center="none" text="Loading script notes..."/>;
@@ -50,7 +58,10 @@ export function ScriptNotes({ script }) {
     return <DefaultErrorMessage />;
   }
 
-  let notes = getNoteFromResponse(data);
+  return <RenderedNotes notes={getNoteFromResponse(data)} />;
+}
+
+export function RenderedNotes({ notes }) {
   if (notes == null || notes === "") {
     return <em>The selected script does not have any notes.</em>;
   }

--- a/client/src/ScriptsPage.js
+++ b/client/src/ScriptsPage.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from "react-router-dom";
+import { Row, Col } from 'reactstrap';
 
 import {
   DefaultErrorMessage,
@@ -10,6 +11,7 @@ import {
   utils,
 } from 'flight-webapp-components';
 
+import ScriptSummary from './ScriptSummary';
 import ScriptsTable from './ScriptsTable';
 import styles from './ScriptsPage.module.css';
 import { useFetchScripts } from './api';
@@ -43,6 +45,8 @@ function ScriptsPage() {
 }
 
 function Layout({ reloadScripts, scripts }) {
+  const [selectedScript, setSelectedScript] = useState(null);
+
   if (scripts == null || !scripts.length) {
     return <NoScriptsFound />;
   }
@@ -50,7 +54,22 @@ function Layout({ reloadScripts, scripts }) {
   return (
     <React.Fragment>
       <IntroCard scripts={scripts} />
-      <ScriptsTable reloadScripts={reloadScripts} scripts={scripts} />
+      <div>
+        <Row>
+          <Col>
+            <ScriptsTable
+              onRowSelect={setSelectedScript}
+              scripts={scripts}
+            />
+          </Col>
+          <Col style={{ paddingTop: 'calc(38px + 16px)' }}>
+            <ScriptSummary
+              reloadScripts={reloadScripts}
+              script={selectedScript}
+            />
+          </Col>
+        </Row>
+      </div>
     </React.Fragment>
   );
 }

--- a/client/src/ScriptsTable.module.css
+++ b/client/src/ScriptsTable.module.css
@@ -2,7 +2,3 @@
     background-color: #fff;
     cursor: pointer;
 }
-
-.ActionsCell {
-    width: 12em;
-}

--- a/client/src/SubmitScriptButton.js
+++ b/client/src/SubmitScriptButton.js
@@ -48,4 +48,19 @@ function SubmitScriptButton({ className, script }) {
   );
 }
 
+function Disabled({ className }) {
+  return (
+    <Button
+      className={classNames(className)}
+      disabled
+      size="sm"
+    >
+      <i className={`fa fa-rocket mr-1`}></i>
+      <span>Submit</span>
+    </Button>
+  );
+}
+
+SubmitScriptButton.Disabled = Disabled;
+
 export default SubmitScriptButton;

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -80,7 +80,7 @@ export function useFetchScripts() {
 export function useFetchScript(id) {
   const { currentUser } = useContext(CurrentUserContext);
   return useFetch(
-    `/scripts/${id}?include=template,note`,
+    `/scripts/${id}?include=template,note,content`,
     {
       headers: { Accept: 'application/vnd.api+json' },
       interceptors: {
@@ -143,6 +143,20 @@ export function useFetchScriptNotes(script) {
   const scriptId = script == null ? undefined : script.id;
   return useFetch(
     `/scripts/${scriptId}/note`,
+    {
+      headers: {
+        Accept: 'application/vnd.api+json',
+      },
+    },
+    [ currentUser.authToken, scriptId ],
+  );
+}
+
+export function useFetchScriptContent(script) {
+  const { currentUser } = useContext(CurrentUserContext);
+  const scriptId = script == null ? undefined : script.id;
+  return useFetch(
+    `/scripts/${scriptId}/content`,
     {
       headers: {
         Accept: 'application/vnd.api+json',

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -50,7 +50,9 @@ export function useGenerateScript(templateId, answers) {
         Accept: 'text/plain',
         'Content-Type': 'application/json',
       },
-      body: answers,
+      body: {
+        answers,
+      },
       cachePolicy: 'no-cache',
     },
   );

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -138,6 +138,20 @@ export function useDeleteScript(script) {
   return request;
 }
 
+export function useFetchScriptNotes(script) {
+  const { currentUser } = useContext(CurrentUserContext);
+  const scriptId = script == null ? undefined : script.id;
+  return useFetch(
+    `/scripts/${scriptId}/note`,
+    {
+      headers: {
+        Accept: 'application/vnd.api+json',
+      },
+    },
+    [ currentUser.authToken, scriptId ],
+  );
+}
+
 function getResourceFromResponse(data) {
   if (!utils.isObject(data)) { return null; }
   return data.data;

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -80,7 +80,7 @@ export function useFetchScripts() {
 export function useFetchScript(id) {
   const { currentUser } = useContext(CurrentUserContext);
   return useFetch(
-    `/scripts/${id}?include=template`,
+    `/scripts/${id}?include=template,note`,
     {
       headers: { Accept: 'application/vnd.api+json' },
       interceptors: {

--- a/client/src/index.module.css
+++ b/client/src/index.module.css
@@ -1,0 +1,9 @@
+.PreCode {
+    background: #343a40; /* bg-dark */
+    color: #f8f9fa; /* text-light */
+    padding: 0.5em;
+    border-radius: 0.5em;
+}
+.ScriptContent {
+    max-height: 48em;
+}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4542,9 +4542,9 @@ flatten@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
 
-"flight-webapp-components@git+https://github.com/openflighthpc/flight-webapp-components#0.1.4":
-  version "0.1.3"
-  resolved "git+https://github.com/openflighthpc/flight-webapp-components#50ee75e7113bdacd93989c94ec4703c23cead612"
+"flight-webapp-components@git+https://github.com/openflighthpc/flight-webapp-components#0.1.5":
+  version "0.1.5"
+  resolved "git+https://github.com/openflighthpc/flight-webapp-components#943814bf05bb5b704406861a101f60150aabf038"
   dependencies:
     classnames "^2.2.6"
     js-gravatar "^1.1.3"
@@ -8148,8 +8148,8 @@ react-error-overlay@^6.0.8:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.8.tgz#474ed11d04fc6bda3af643447d85e9127ed6b5de"
 
 react-hook-form@^6.15.4:
-  version "6.15.4"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.15.4.tgz#328003e1ccc096cd158899ffe7e3b33735a9b024"
+  version "6.15.7"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.15.7.tgz#e5ad7a9f73b0311ee770c56951276a3b85b06656"
 
 react-input-autosize@^3.0.0:
   version "3.0.0"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4904,6 +4904,10 @@ hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
 
+highlight.js@^10.7.2:
+  version "10.7.2"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.2.tgz#89319b861edc66c48854ed1e6da21ea89f847360"
+
 history@^4.9.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"


### PR DESCRIPTION
This PR adds read-only support for script notes and content to the webapp.  Editing the scripts and notes will follow in a future PR.

The API's script serializer has been extended to `has_one` `note` and `content`.

The scripts table has been reworked to display the notes for the selected script.  The selected columns for the script have been reduced, in particular, the location of the script on disk is no longer displayed.  These changes have also had the side-effect of fixing an issue where submitting a script from the script table, would erroneously report that the submission had failed.

![image](https://user-images.githubusercontent.com/287050/115750713-616bb980-a390-11eb-8e3e-cfaabc1c5b4c.png)

![image](https://user-images.githubusercontent.com/287050/115751162-d2ab6c80-a390-11eb-9fb8-c861a98ff519.png)

![image](https://user-images.githubusercontent.com/287050/115751193-da6b1100-a390-11eb-97ed-939ded83dfd6.png)

![image](https://user-images.githubusercontent.com/287050/115751303-fa9ad000-a390-11eb-8c68-7bf6a09de342.png)

---

The script page has been extend to display both the notes and the content.  The content is highlighted and scrolled such that the line `# >>>> YOUR WORKLOAD` is scrolled to the top.

![image](https://user-images.githubusercontent.com/287050/115751356-09818280-a391-11eb-948d-335b331d1426.png)

![image](https://user-images.githubusercontent.com/287050/115751428-169e7180-a391-11eb-9227-18a2919f0b58.png)
