### PR TITLE
Expose the result files/stdout/stderr through the API

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -35,6 +35,7 @@ gem 'flight_auth', github: "openflighthpc/flight_auth", branch: "297cb7241b820d3
 gem 'flight_configuration', github: 'openflighthpc/flight_configuration', branch: '24928260e542768f13cc513a3a08af69f690dfbc'
 gem 'concurrent-ruby'
 gem 'json_schemer'
+gem 'mime-types'
 gem 'rack-parser', require: 'rack/parser'
 gem 'rake'
 gem 'request_store'

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -46,6 +46,9 @@ GEM
       activesupport
     jwt (2.2.3)
     method_source (1.0.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0225)
     minitest (5.14.3)
     multi_json (1.15.0)
     mustermann (1.1.1)
@@ -123,6 +126,7 @@ DEPENDENCIES
   flight_configuration!
   json_schemer
   jwt
+  mime-types
   pry
   pry-byebug
   puma

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
       uri_template (~> 0.7)
     jsonapi-serializers (1.0.1)
       activesupport
-    jwt (2.2.2)
+    jwt (2.2.3)
     method_source (1.0.0)
     minitest (5.14.3)
     multi_json (1.15.0)
@@ -103,7 +103,7 @@ GEM
       jsonapi-serializers (>= 0.16.2, < 2)
       sinatra (>= 2.0.0.rc1, < 3)
       sinatra-contrib (>= 2.0.0.rc1, < 3)
-    slop (4.8.2)
+    slop (4.9.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
     tzinfo (1.2.9)

--- a/api/app.rb
+++ b/api/app.rb
@@ -236,6 +236,18 @@ class App < Sinatra::Base
         next resource.index_result_files
       end
     end
+
+    has_one :stdout_file do
+      pluck do
+        next resource.find_stdout_file
+      end
+    end
+
+    has_one :stderr_file do
+      pluck do
+        next resource.find_stderr_file
+      end
+    end
   end
 
   resource :files, pkre: /[\w-]+\.[\w=-]+/ do

--- a/api/app.rb
+++ b/api/app.rb
@@ -224,6 +224,16 @@ class App < Sinatra::Base
     end
   end
 
+  resource :files, pkre: /[\w-]+\.[\w=-]+/ do
+    helpers do
+      def find(id)
+        JobFile.find!(id, user: current_user)
+      end
+    end
+
+    show
+  end
+
   freeze_jsonapi
 end
 

--- a/api/app.rb
+++ b/api/app.rb
@@ -118,10 +118,7 @@ class App < Sinatra::Base
   # "files" resources.
   before do
     params["fields"] ||= {}
-    params["fields"]["files"] ||= begin
-      @default_files_sparse_fieldset = true
-      JobFileSerializer::DEFAULT_SPARSE_FIELDSET
-    end
+    params["fields"]["files"] ||= JobFileSerializer::DEFAULT_SPARSE_FIELDSET
   end
 
   resource :templates, pkre: /[\w.-]+/ do

--- a/api/app.rb
+++ b/api/app.rb
@@ -236,7 +236,7 @@ class App < Sinatra::Base
 
     has_many :result_files do
       fetch do
-        next resource.index_job_results
+        next resource.index_result_files
       end
     end
   end

--- a/api/app/models/job.rb
+++ b/api/app/models/job.rb
@@ -107,4 +107,8 @@ class Job
 
     @metadata = JSON.parse(cmd.stdout)
   end
+
+  def index_result_files
+    JobFile.index_job_results(self)
+  end
 end

--- a/api/app/models/job.rb
+++ b/api/app/models/job.rb
@@ -111,4 +111,12 @@ class Job
   def index_result_files
     JobFile.index_job_results(self)
   end
+
+  def find_stdout_file
+    JobFile.find!("#{id}.stdout", user: user)
+  end
+
+  def find_stderr_file
+    JobFile.find!("#{id}.stderr", user: user)
+  end
 end

--- a/api/app/models/job.rb
+++ b/api/app/models/job.rb
@@ -109,7 +109,7 @@ class Job
   end
 
   def index_result_files
-    JobFile.index_job_results(self)
+    JobFile.index_job_results!(self.id, user: user)
   end
 
   def find_stdout_file

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -147,6 +147,15 @@ class JobFile
     Job.find!(@job_id, user: @user)
   end
 
+  def decoded_file_id
+    @decoded_file_id unless @decoded_file_id.nil?
+    return @decoded_file_id = false if ['stdout', 'stderr'].include?(@file_id)
+    @decoded_file_id ||= Base64.urlsafe_decode64(@file_id)
+  rescue ArgumentError
+    # urlsafe_decode64 may raise ArgumentError if @file_id is invalid
+    @decoded_file_id = false
+  end
+
   def path
     @path unless @path.nil?
     case @file_id
@@ -189,14 +198,6 @@ class JobFile
   end
 
   private
-
-  def decoded_file_id
-    @decoded_file_id unless @decoded_file_id.nil?
-    @decoded_file_id ||= Base64.urlsafe_decode64(@file_id)
-  rescue ArgumentError
-    # urlsafe_decode64 may raise ArgumentError if @file_id is invalid
-    @decoded_file_id = false
-  end
 
   def payload_command
     return @payload_command unless @payload_command.nil?

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -54,7 +54,7 @@ class JobFile
       cmd.stdout.each_line.map do |line|
         # When flagged to do so, set the current_dir and skip the line
         if current_dir.nil?
-          current_dir ||= line.sub(/:\n\Z/, '')
+          current_dir = line.sub(/:\n\Z/, '')
           results_dir ||= current_dir
           next
         end
@@ -148,16 +148,16 @@ class JobFile
   end
 
   def decoded_file_id
-    @decoded_file_id unless @decoded_file_id.nil?
+    return @decoded_file_id unless @decoded_file_id.nil?
     return @decoded_file_id = false if ['stdout', 'stderr'].include?(@file_id)
-    @decoded_file_id ||= Base64.urlsafe_decode64(@file_id)
+    @decoded_file_id = Base64.urlsafe_decode64(@file_id)
   rescue ArgumentError
     # urlsafe_decode64 may raise ArgumentError if @file_id is invalid
     @decoded_file_id = false
   end
 
   def path
-    @path unless @path.nil?
+    return @path unless @path.nil?
     case @file_id
     when 'stdout'
       @path = find_job.metadata['stdout_path']

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -47,7 +47,15 @@ class JobFile
       # Find the relevant files
       cmd = FlightJobScriptAPI::SystemCommand.find(dir, '-type', 'f', user: job.user)
       unless cmd.exitstatus == 0
-        raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to load results files for job: #{job.id}"
+        # NOTE: 'find' could fail for a few different reasons, which boil down to:
+        # * The directory does not exist (yet), or
+        # * The user lacks the appropriate permissions
+        #
+        # Permission issues would be unusual as the job was probably ran from the working
+        # directory. In this case, it can be assumed the user does not have any result files.
+        #
+        # This means all errors should be interpreted as "no result files found"
+        return []
       end
 
       cmd.stdout.split("\n").map do |abs_path|

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
+#
+# This file is part of Flight Job Script Service.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Job Script Service is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Job Script Service. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Job Script Service, please visit:
+# https://github.com/openflighthpc/flight-job-script-service
+#==============================================================================
+
+class JobFile
+  class << self
+    prepend FlightJobScriptAPI::ModelCache
+
+    def find!(id, **opts)
+      job_id, file_id = id.split('.', 2)
+      new(job_id, file_id, user: opts[:user]).tap do |job_file|
+        return nil unless job_file.exists?
+      end
+    end
+  end
+
+  # NOTE: The file_id could be one of the following:
+  # * 'stdout' - Denotes the standard output,
+  # * 'stderr' - Denotes the standard error], or
+  # * 'encoded_string' - The relative path to the file as a urlsafe base64 encoded string
+  #
+  # PS: The strings 'stdout'/'stderr' are invalid inputs to urlsafe_decode64 and thus
+  # can be used as special case inputs.
+  def initialize(job_id, file_id, user:)
+    @job_id = job_id
+    @file_id = file_id
+    @user = user
+  end
+
+  def id
+    "#{@job_id}.#{@file_id}"
+  end
+
+  def exists?
+    payload # Attempts to load the payload
+    true
+  rescue FlightJobScriptAPI::CommandError
+    # The file does not exists due to a bad name
+    return false unless payload_command
+
+    # The file or job legitimately does not exist
+    return false if [20, 23].include? payload_command.exitstatus
+
+    # Something else has gone wrong, re-raise the error
+    raise $!
+  end
+
+  def filename
+    @filename unless @filename.nil?
+    # XXX: Should the actual name of stdout/stdderr be exposed?
+    #      This would require running another command to load the job
+    @filename = false if ['stdout', 'stderr'].include?(@file_id)
+    @filename = Base64.urlsafe_decode64(@file_id)
+  rescue ArgumentError
+    # urlsafe_decode64 may raise ArgumentError if @file_id is invalid
+    @filename = false
+  end
+
+  # Intentionally raises CommandError if the command exited NotFound (codes 20/23).
+  # This is because a JobFile may be cached based on the result of a list
+  # command which did not load the payload.
+  #
+  # As these models are already cached, the *should* exist. Thus a 50X server error
+  # is more appropriate than 404.
+  def payload
+    if payload_command&.exitstatus == 0
+      payload_command.stdout
+    else
+      raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to load file: #{id}"
+    end
+  end
+
+  private
+
+  def payload_command
+    return @payload_command unless @payload_command.nil?
+    @payload_command = if @file_id == 'stdout'
+      FlightJobScriptAPI::SystemCommand.flight_view_job_stdout(@job_id, user: @user)
+    elsif @file_id == 'stderr'
+      FlightJobScriptAPI::SystemCommand.flight_view_job_stderr(@job_id, user: @user)
+    elsif filename
+      FlightJobScriptAPI::SystemCommand.flight_view_job_results(@job_id, filename, user: @user)
+    else
+      false
+    end
+  end
+end

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -118,12 +118,15 @@ class JobFile
   end
 
   def relative_path
-    return @relative_path unless @relative_path.nil?
-    @relative_path = if ['stdout', 'stderr'].include?(@file_id) && path
-      Pathname.new(path).relative_path_from(find_job.metadata['results_dir']).to_s
-    else
-      decoded_file_id
-    end
+    decoded_file_id
+    # XXX Add back support for 'stdout' and 'stderr'.  It needs to not break
+    # for jobs that have not reported their results dir.
+    # return @relative_path unless @relative_path.nil?
+    # @relative_path = if ['stdout', 'stderr'].include?(@file_id) && path
+    #   Pathname.new(path).relative_path_from(find_job.metadata['results_dir']).to_s
+    # else
+    #   decoded_file_id
+    # end
   end
 
   def decoded_file_id

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -59,7 +59,7 @@ class JobFile
 
     def find!(id, **opts)
       job_id, file_id = id.split('.', 2)
-      new(job_id, file_id, user: job.user).tap do |job_file|
+      new(job_id, file_id, user: opts[:user]).tap do |job_file|
         return nil unless job_file.exists?
       end
     end

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -33,12 +33,14 @@ class JobFile
     prepend FlightJobScriptAPI::ModelCache
 
     def index_job_results!(job_id, user:)
-      # Find the relevant files
-      cmd = FlightJobScriptAPI::SystemCommand.flight_list_job_results(job_id, user: user)
+      # Load up the job
+      job = Job.find!(job_id, user: user)
+      return nil unless job
+      return nil unless job.metadata['results_dir']
+      results_dir = job.metadata['results_dir']
 
-      # Return nil if the job is missing
-      # NOTE: This distinguishes between job's without any result files and missing jobs
-      return nil if cmd.exitstatus == 23
+      # Find the relevant files
+      cmd = FlightJobScriptAPI::SystemCommand.recursive_glob_dir(results_dir, user: user)
 
       # Return empty array if the results directory is missing
       return [] if cmd.exitstatus == 20
@@ -48,45 +50,13 @@ class JobFile
         raise CommandError, "Failed to load the result files for job: #{job_id}"
       end
 
-      # Process the output from ls
-      results_dir = nil
-      current_dir = nil
-      cmd.stdout.each_line.map do |line|
-        # When flagged to do so, set the current_dir and skip the line
-        if current_dir.nil?
-          current_dir = line.sub(/:\n\Z/, '')
-          results_dir ||= current_dir
-          next
-        end
-
-        # Skip total lines
-        next if /\Atotal \d+\Z/.match?(line)
-
-        # Flag the next line will be the current_dir and skip
-        if line == "\n"
-          current_dir = nil
-          next
-        end
-
-        # Split the line into its components
-        # NOTE: Maxing it out as 9 fields allows for files which contain a space character
-        perm, _l, _u, _g, size, _m, _d, _t, name = line.chomp.split(' ', 9)
-
-        # Skip directories and symbolic links
-        # NOTE: Following symbolic links may cause security issues if not handled with care
-        #       For the time being it's best to ignore them
-        next if perm.include?('d') || perm.include?('l')
-
-        # Generate the relative path and file_id
-        rel_path = Pathname.new(name).expand_path(current_dir).relative_path_from(results_dir).to_s
-        file_id = Base64.urlsafe_encode64(rel_path)
-        id = "#{job_id}.#{file_id}"
-
-        # Load or build and cache a new file
-        get_from_cache(id) || JobFile.new(job_id, file_id, user: user, size: size).tap do |file|
-          set_in_cache(id, file)
-        end
-      end.reject(&:nil?).sort
+      # Construct the files
+      JSON.parse(cmd.stdout).map do |payload|
+        file = payload['file']
+        size = payload['size']
+        file_id = Base64.urlsafe_encode64 Pathname.new(file).relative_path_from(results_dir).to_s
+        JobFile.new(job.id, file_id, user: user, size: size)
+      end
     end
 
     def find!(id, **opts)

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -147,6 +147,15 @@ class JobFile
     Job.find!(@job_id, user: @user)
   end
 
+  def relative_path
+    return @relative_path unless @relative_path.nil?
+    @relative_path = if ['stdout', 'stderr'].include?(@file_id) && path
+      Pathname.new(path).relative_path_from(find_job.metadata['results_dir']).to_s
+    else
+      decoded_file_id
+    end
+  end
+
   def decoded_file_id
     return @decoded_file_id unless @decoded_file_id.nil?
     return @decoded_file_id = false if ['stdout', 'stderr'].include?(@file_id)

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -86,7 +86,7 @@ class JobFile
         get_from_cache(id) || JobFile.new(job_id, file_id, user: user, size: size).tap do |file|
           set_in_cache(id, file)
         end
-      end.reject(&:nil?)
+      end.reject(&:nil?).sort
     end
 
     def find!(id, **opts)
@@ -166,6 +166,12 @@ class JobFile
     else
       raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to load file: #{id}"
     end
+  end
+
+  protected
+
+  def <=>(other)
+    filename <=> other.filename
   end
 
   private

--- a/api/app/serializers/job_file_serializer.rb
+++ b/api/app/serializers/job_file_serializer.rb
@@ -28,7 +28,7 @@
 
 class JobFileSerializer < ApplicationSerializer
   # NOTE: Update this constant as new attributes are added
-  DEFAULT_SPARSE_FIELDSET = "filename"
+  DEFAULT_SPARSE_FIELDSET = "filename,size"
 
   def type
     'files'
@@ -41,6 +41,11 @@ class JobFileSerializer < ApplicationSerializer
         specifying a sparse fieldset: 'fields[files]=payload'
       INFO
     end
+  end
+
+  # Recalculate the file size if the payload will be included in the request
+  attribute(:size) do
+    object.size(recalculate: @_fields.fetch('files', []).include?(:payload))
   end
 
   # Forces the file to be UTF-8 encoded

--- a/api/app/serializers/job_file_serializer.rb
+++ b/api/app/serializers/job_file_serializer.rb
@@ -28,7 +28,7 @@
 
 class JobFileSerializer < ApplicationSerializer
   # NOTE: Update this constant as new attributes are added
-  DEFAULT_SPARSE_FIELDSET = "path,decodedPath,filename,size"
+  DEFAULT_SPARSE_FIELDSET = "path,decodedPath,filename,size,mimeType"
 
   def type
     'files'
@@ -49,6 +49,7 @@ class JobFileSerializer < ApplicationSerializer
   end
 
   # Forces the file to be UTF-8 encoded
+  # NOTE: This assumes binary files are not supported
   attribute(:payload) { object.payload.force_encoding('utf-8') }
 
   # Hide that path could be set to "false". This is for internal caching
@@ -57,6 +58,9 @@ class JobFileSerializer < ApplicationSerializer
   attribute(:decoded_path) { object.decoded_file_id || nil }
 
   attribute :filename
+
+  # NOTE: The default is text/plain because the string encoding is forced to be UTF8
+  attribute(:mime_type) { MIME::Types.type_for(object.filename)&.first&.content_type || 'text/plain' }
 
   has_one(:job) { object.find_job }
 end

--- a/api/app/serializers/job_file_serializer.rb
+++ b/api/app/serializers/job_file_serializer.rb
@@ -28,7 +28,7 @@
 
 class JobFileSerializer < ApplicationSerializer
   # NOTE: Update this constant as new attributes are added
-  DEFAULT_SPARSE_FIELDSET = "path,decodedPath,filename,size,mimeType"
+  DEFAULT_SPARSE_FIELDSET = "path,relativePath,filename,size,mimeType"
 
   def type
     'files'
@@ -55,7 +55,7 @@ class JobFileSerializer < ApplicationSerializer
   # Hide that path could be set to "false". This is for internal caching
   # purposes.
   attribute(:path) { object.path || nil }
-  attribute(:decoded_path) { object.decoded_file_id || nil }
+  attribute(:relative_path) { object.relative_path || nil }
 
   attribute :filename
 

--- a/api/app/serializers/job_file_serializer.rb
+++ b/api/app/serializers/job_file_serializer.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
+#
+# This file is part of Flight Job Script Service.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Job Script Service is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Job Script Service. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Job Script Service, please visit:
+# https://github.com/openflighthpc/flight-job-script-service
+#==============================================================================
+
+class JobFileSerializer < ApplicationSerializer
+  def type
+    'files'
+  end
+
+  # Forces the file to be UTF-8 encoded
+  attribute(:payload) { object.payload.force_encoding('utf-8') }
+
+  # Hide that filename could be set to "false". This is for internal caching
+  # purposes.
+  attribute(:filename) { object.filename || nil }
+end

--- a/api/app/serializers/job_file_serializer.rb
+++ b/api/app/serializers/job_file_serializer.rb
@@ -27,8 +27,20 @@
 #==============================================================================
 
 class JobFileSerializer < ApplicationSerializer
+  # NOTE: Update this constant as new attributes are added
+  DEFAULT_SPARSE_FIELDSET = "filename"
+
   def type
     'files'
+  end
+
+  def meta
+    unless attributes.keys.include?("payload")
+      <<~INFO.squish
+        The 'payload' attribute is hidden by default. It can be returned by
+        specifying a sparse fieldset: 'fields[files]=payload'
+      INFO
+    end
   end
 
   # Forces the file to be UTF-8 encoded

--- a/api/app/serializers/job_file_serializer.rb
+++ b/api/app/serializers/job_file_serializer.rb
@@ -28,7 +28,7 @@
 
 class JobFileSerializer < ApplicationSerializer
   # NOTE: Update this constant as new attributes are added
-  DEFAULT_SPARSE_FIELDSET = "filename,size"
+  DEFAULT_SPARSE_FIELDSET = "path,filename,size"
 
   def type
     'files'
@@ -51,7 +51,10 @@ class JobFileSerializer < ApplicationSerializer
   # Forces the file to be UTF-8 encoded
   attribute(:payload) { object.payload.force_encoding('utf-8') }
 
-  # Hide that filename could be set to "false". This is for internal caching
+  # Hide that path could be set to "false". This is for internal caching
   # purposes.
-  attribute(:filename) { object.filename || nil }
+  attribute(:path) { object.path || nil }
+  attribute :filename
+
+  has_one(:job) { object.find_job }
 end

--- a/api/app/serializers/job_file_serializer.rb
+++ b/api/app/serializers/job_file_serializer.rb
@@ -28,7 +28,7 @@
 
 class JobFileSerializer < ApplicationSerializer
   # NOTE: Update this constant as new attributes are added
-  DEFAULT_SPARSE_FIELDSET = "path,filename,size"
+  DEFAULT_SPARSE_FIELDSET = "path,decodedPath,filename,size"
 
   def type
     'files'
@@ -54,6 +54,8 @@ class JobFileSerializer < ApplicationSerializer
   # Hide that path could be set to "false". This is for internal caching
   # purposes.
   attribute(:path) { object.path || nil }
+  attribute(:decoded_path) { object.decoded_file_id || nil }
+
   attribute :filename
 
   has_one(:job) { object.find_job }

--- a/api/app/serializers/job_serializer.rb
+++ b/api/app/serializers/job_serializer.rb
@@ -36,5 +36,7 @@ class JobSerializer < ApplicationSerializer
   end
 
   has_one :script
+  has_one(:stdout_file) { object.find_stdout_file }
+  has_one(:stderr_file) { object.find_stderr_file }
   has_many(:result_files) { object.index_result_files }
 end

--- a/api/app/serializers/job_serializer.rb
+++ b/api/app/serializers/job_serializer.rb
@@ -29,7 +29,8 @@
 class JobSerializer < ApplicationSerializer
   [
     'created_at', 'stdout_path', 'stderr_path', 'state', 'reason',
-    'start_time', 'end_time', 'scheduler_id', 'submit_stdout', 'submit_stderr'
+    'start_time', 'end_time', 'scheduler_id', 'submit_stdout', 'submit_stderr',
+    'results_dir'
   ].each do |field|
     attribute(field) { object.metadata[field] }
   end

--- a/api/app/serializers/job_serializer.rb
+++ b/api/app/serializers/job_serializer.rb
@@ -35,6 +35,12 @@ class JobSerializer < ApplicationSerializer
     attribute(field) { object.metadata[field] }
   end
 
+  attribute(:merged_stderr) do
+    paths = object.metadata.slice('stdout_path', 'stderr_path').values.uniq
+    return nil if paths.length == 1 && paths.first.nil?
+    paths.length == 1
+  end
+
   has_one :script
   has_one(:stdout_file) { object.find_stdout_file }
   has_one(:stderr_file) { object.find_stderr_file }

--- a/api/app/serializers/job_serializer.rb
+++ b/api/app/serializers/job_serializer.rb
@@ -36,4 +36,5 @@ class JobSerializer < ApplicationSerializer
   end
 
   has_one :script
+  has_many(:result_files) { object.index_result_files }
 end

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -682,9 +682,10 @@ HTTP/2 200 OK
 {
   "data": {                     # REQUIRED - The FileResource
     "type": "files",            # REQUIRED - Specfies the resource is a file
-    "id": STRING,               # REQUIRED - The file's ID (:job_id.:encoded_name)
+    "id": STRING,               # REQUIRED - The file's ID (:job_id.:encoded_relative_path)
     "attributes":{
-      "filename" STRING,        # REQUIRED - The name of the file
+      "filename": STRING,       # REQUIRED - The name of the file
+      "decoded_path": STRING    # OPTIONAL - The clear text version of file's relative path (omitted for stdout/stderr)
       "path": STRING,           # REQUIRED - The path to the file
       "size": INTEGER,          # REQUIRED - The size of the file in Bytes
     },

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -684,7 +684,9 @@ HTTP/2 200 OK
     "type": "files",            # REQUIRED - Specfies the resource is a file
     "id": STRING,               # REQUIRED - The file's ID (:job_id.:encoded_name)
     "attributes":{
-      "filename" STRING         # RECOMMENDED - The decoded filename (null when returning stdout/stderr)
+      "filename" STRING,        # REQUIRED - The name of the file
+      "path": STRING,           # REQUIRED - The path to the file
+      "size": INTEGER,          # REQUIRED - The size of the file in Bytes
     },
     "links": {
       "self": "/v0/files/:id"

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -685,7 +685,9 @@ HTTP/2 200 OK
     "id": STRING,               # REQUIRED - The file's ID (:job_id.:encoded_relative_path)
     "attributes":{
       "filename": STRING,       # REQUIRED - The name of the file
-      "decoded_path": STRING    # OPTIONAL - The clear text version of file's relative path (omitted for stdout/stderr)
+      "mimeType": STRING,       # REQUIRED - The predicted MIME type of the file from the file extension
+                                             Warning: This could be incorrect
+      "decoded_path": STRING,   # OPTIONAL - The clear text version of file's relative path (omitted for stdout/stderr)
       "path": STRING,           # REQUIRED - The path to the file
       "size": INTEGER,          # REQUIRED - The size of the file in Bytes
     },

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -687,8 +687,8 @@ HTTP/2 200 OK
       "filename": STRING,       # REQUIRED - The name of the file
       "mimeType": STRING,       # REQUIRED - The predicted MIME type of the file from the file extension
                                              Warning: This could be incorrect
-      "decoded_path": STRING,   # OPTIONAL - The clear text version of file's relative path (omitted for stdout/stderr)
-      "path": STRING,           # REQUIRED - The path to the file
+      "relative_path": STRING,  # RECOMMENDED - The relative path to the file from the results_dir
+      "path": STRING,           # RECOMMENDED - The path to the file
       "size": INTEGER,          # REQUIRED - The size of the file in Bytes
     },
     "links": {

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -623,6 +623,47 @@ Content-Type: application/vnd.api+json
 }
 ```
 
+## GET - /jobs/:id/stdout-file
+
+Return the related `stdout` for the `job`.
+
+```
+GET /v0/jobs/:id/stdout-file
+Authorization: basic <base64 username:password>
+Accept: application/vnd.api+json
+
+HTTP/2 200 OK
+Content-Type: application/vnd.api+json
+{
+  "data": FileResource,
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "included": [
+  ]
+}
+```
+
+## GET - /jobs/:id/stderr-file
+
+Return the related `stderr` for the `job`.
+
+```
+GET /v0/jobs/:id/stderr-file
+Authorization: basic <base64 username:password>
+Accept: application/vnd.api+json
+
+HTTP/2 200 OK
+Content-Type: application/vnd.api+json
+{
+  "data": FileResource,
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "included": [
+  ]
+}
+```
 
 ## POST - /jobs
 

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -629,6 +629,49 @@ Content-Type: application/vnd.api+json
 }
 ```
 
+## GET - /files/:job_id.:encoded_name
+
+Return the results `file` for a particular `job_id`. The `encoded_name` should be one of the following:
+
+* `stdout`: Return the standard output of the job,
+* `stderr`: Return the standard error of the job, or
+* `<filename-base64>`: The relative path to any file contained within the job's working directory as a base64 encoded string \*
+
+\* Base64 is used to encode the file paths to allow for sub directories.
+
+```
+GET /v0/files/:job_id.:encoded_name
+Authorization: Bearer <jwt>
+Accept: application/vnd.api+json
+Content-Type: application/vnd.api+json
+
+HTTP/2 200 OK
+{
+  "data": {                     # REQUIRED - The FileResource
+    "type": "files",            # REQUIRED - Specfies the resource is a file
+    "id": STRING,               # REQUIRED - The file's ID (:job_id.:encoded_name)
+    "attributes":{
+      "filename" STRING,        # RECOMMENDED - The decoded filename (null when returning stdout/stderr)
+      "payload": STRING         # REQUIRED - The content of the file using UTF-8 encoding
+    },
+    "links": {
+      "self": "/v0/files/:id"
+    }
+    "relationships": {
+    }
+  },
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "included": [
+  ]
+}
+
+# Returns the Standard Output and Error respectively
+GET /v0/files/:job_id.stdout
+GET /v0/files/:job_id.stderr
+```
+
 ## POST - /render/:template_id
 
 Renders the template against the provided date and saves it to the filesystem.

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -567,7 +567,8 @@ Content-Type: application/vnd.api+json
       "startTime": DATETIME,    # OPTIONAL - The actual (or predicted) time the job started running
       "endTime": DATETIME,      # OPTIONAL - The actual (or predicted) time the job will finish running
       "submitStdout": STRING,   # RECOMMENDED - The standard output of the underlining scheduler command
-      "submitStderr": STRING    # RECOMMENDED - The standard error of the underlining scheduler command
+      "submitStderr": STRING,   # RECOMMENDED - The standard error of the underlining scheduler command
+      "resultsDir": STRING      # RECOMMENDED - The directory that will store the results files (excluding STDOUT/STDERR)
     },
     "links": {
       "self": "/v0/jobs/:id"

--- a/api/lib/flight_job_script_api.rb
+++ b/api/lib/flight_job_script_api.rb
@@ -30,6 +30,7 @@ module FlightJobScriptAPI
   autoload(:Configuration, 'flight_job_script_api/configuration')
   autoload(:ModelCache, 'flight_job_script_api/model_cache')
   autoload(:SystemCommand, 'flight_job_script_api/system_command')
+  autoload(:CommandError, 'flight_job_script_api/system_command')
 
   class UnexpectedError < StandardError; end
 

--- a/api/lib/flight_job_script_api/system_command.rb
+++ b/api/lib/flight_job_script_api/system_command.rb
@@ -102,7 +102,7 @@ module FlightJobScriptAPI
     end
 
     def self.flight_list_job_results(job_id, **opts)
-      env = { 'LC_TIME' => 'POSIX' } # Ensure a consistent time format
+      env = { 'LC_ALL' => 'POSIX' } # Ensure a consistent output to ls
       new(*FlightJobScriptAPI.config.flight_job, 'list-job-results', job_id, '--', '-lAR', env: env, **opts).tap(&:run)
     end
 

--- a/api/lib/flight_job_script_api/system_command.rb
+++ b/api/lib/flight_job_script_api/system_command.rb
@@ -101,6 +101,18 @@ module FlightJobScriptAPI
       new(*FlightJobScriptAPI.config.flight_job, 'submit-job', script_id, '--json', **opts).tap(&:run)
     end
 
+    def self.flight_view_job_stdout(job_id, **opts)
+      new(*FlightJobScriptAPI.config.flight_job, 'view-job-stdout', job_id, **opts).tap(&:run)
+    end
+
+    def self.flight_view_job_stderr(job_id, **opts)
+      new(*FlightJobScriptAPI.config.flight_job, 'view-job-stderr', job_id, **opts).tap(&:run)
+    end
+
+    def self.flight_view_job_results(job_id, filename, **opts)
+      new(*FlightJobScriptAPI.config.flight_job, 'view-job-results', job_id, filename, **opts).tap(&:run)
+    end
+
     attr_reader :cmd, :user, :mutex, :stdin
     attr_accessor :stdout, :stderr, :exitstatus
 

--- a/api/lib/flight_job_script_api/system_command.rb
+++ b/api/lib/flight_job_script_api/system_command.rb
@@ -113,6 +113,10 @@ module FlightJobScriptAPI
       new(*FlightJobScriptAPI.config.flight_job, 'view-job-results', job_id, filename, **opts).tap(&:run)
     end
 
+    def self.find(*args, **opts)
+      new('find', *args, **opts).tap(&:run)
+    end
+
     attr_reader :cmd, :user, :mutex, :stdin
     attr_accessor :stdout, :stderr, :exitstatus
 

--- a/api/lib/flight_job_script_api/system_command.rb
+++ b/api/lib/flight_job_script_api/system_command.rb
@@ -27,6 +27,7 @@
 #==============================================================================
 
 require 'securerandom'
+require 'pathname'
 
 module FlightJobScriptAPI
   class CommandError < Sinja::ServiceUnavailable; end
@@ -101,11 +102,6 @@ module FlightJobScriptAPI
       new(*FlightJobScriptAPI.config.flight_job, 'submit-job', script_id, '--json', **opts).tap(&:run)
     end
 
-    def self.flight_list_job_results(job_id, **opts)
-      env = { 'LC_ALL' => 'POSIX' } # Ensure a consistent output to ls
-      new(*FlightJobScriptAPI.config.flight_job, 'list-job-results', job_id, '--', '-lAR', env: env, **opts).tap(&:run)
-    end
-
     def self.flight_view_job_stdout(job_id, **opts)
       new(*FlightJobScriptAPI.config.flight_job, 'view-job-stdout', job_id, **opts).tap(&:run)
     end
@@ -116,6 +112,21 @@ module FlightJobScriptAPI
 
     def self.flight_view_job_results(job_id, filename, **opts)
       new(*FlightJobScriptAPI.config.flight_job, 'view-job-results', job_id, filename, **opts).tap(&:run)
+    end
+
+    def self.recursive_glob_dir(dir, **opts)
+      new(:noop, 'recursively glob directory', **opts).tap do |sys|
+        sys.run do
+          exit 20 unless Dir.exists?(dir)
+          json = Dir.glob(File.join(dir, '**/*'))
+                    .map { |p| Pathname.new(p) }
+                    .reject(&:directory?)
+                    .reject(&:symlink?)
+                    .select(&:readable?) # XXX: Non-readable files would be an odd occurrence
+                    .map { |p| { file: p.to_s, size: p.size } }
+          puts JSON.generate(json)
+        end
+      end
     end
 
     attr_reader :cmd, :user, :mutex, :stdin, :env
@@ -147,6 +158,10 @@ module FlightJobScriptAPI
 
         FlightJobScriptAPI.logger.debug("Forking Process")
         pid = Kernel.fork do
+          # Log the command has been forked
+          log_cmd = (cmd.first == :noop ? cmd[1..-1] : cmd).join(' ')
+          FlightJobScriptAPI.logger.info("Forked Command (#{user}): #{log_cmd}")
+
           # Close the parent pipes
           out_read.close
           err_read.close
@@ -159,16 +174,22 @@ module FlightJobScriptAPI
 
           # Allow the command to be modified after becoming the requested user
           # This is useful when trying to create a file with the correct file permissions
+          $stdout = out_write
+          $stderr = err_write
           block.call if block
 
-          # Execute the command
-          opts = {
-            unsetenv_others: true, close_others: true, chdir: passwd.dir,
-            out: out_write, err: err_write, in: in_read
-          }
-          # NOTE: Keep the log before the exec for timing purposes
-          FlightJobScriptAPI.logger.info("Executing (#{user}): #{cmd.join(' ')}")
-          Kernel.exec(env, *cmd, **opts)
+          if cmd.first == :noop
+             FlightJobScriptAPI.logger.debug("Nothing to exec")
+          else
+            # Execute the command
+            opts = {
+              unsetenv_others: true, close_others: true, chdir: passwd.dir,
+              out: out_write, err: err_write, in: in_read
+            }
+            # NOTE: Keep the log before the exec for timing purposes
+            FlightJobScriptAPI.logger.info("Executing (#{user}): #{cmd.join(' ')}")
+            Kernel.exec(env, *cmd, **opts)
+          end
         end
 
         # Close the child pipes


### PR DESCRIPTION
## Standard GET routes

A new end point has been added to allow files to be downloaded. It comes in three different "flavours" to allow for `stdout`, `stderr`, and result files respectively:

* `GET /files/<job_id>.stdout`
* `GET /files/<job_id>.stderr`
* `GET /files/<job_id>.<base64-filename>`

For arbitrary files, the `filename` is `bas64` urlsafe encoded. This allows for filenames which contain `/` because they are within sub-directories. It also prevents issue with the various valid filename characters which are not URL safe.

Serendipitously, both `stdout` and `stderr` are invalid base64 encodings and can be special cased without creating a conflict.

---

## Indexing and sparse fieldset

An additional indexing route has been added, which returns the list of result files for a particular `job`:

`GET /jobs/:id/result-files`

Because loading all the files for a `job` is a large operation, a default sparse-fieldset is used. This means the `payload` for each `file` resource is not returned by default. Instead it needs to be selected explicitly with `fields[files]=payload,...`.

This default sparse field set applies for all `files` routes and `includes` for consistency.

---

Potential issues with redirects:

Because `stdout`/`stderr` could be redirected anywhere in the file system it can cause various issues. The security implications have been mitigated by switching user before attempting to read the file. This prevents the user from reading arbitrary files via the redirect.

However there are various `/dev` files which the user does have permission to:
* `/dev/null` - Works as expected and returns empty string,
* `/dev/random` - Errors with 503 due to a timeout

This issue maybe better handled with `flight-job`, so no fix has been proposed within this PR. Sufficiently large output files will also cause a similar issue, however the exact limit is undefined.