### PR TITLE
Job page performance

### DIFF
--- a/api/app.rb
+++ b/api/app.rb
@@ -237,6 +237,12 @@ class App < Sinatra::Base
       end
     end
 
+    has_many :output_files do
+      fetch do
+        next resource.index_output_files
+      end
+    end
+
     has_one :stdout_file do
       pluck do
         next resource.find_stdout_file

--- a/api/app/models/job.rb
+++ b/api/app/models/job.rb
@@ -112,6 +112,10 @@ class Job
     JobFile.index_job_results(self.id, user: user)
   end
 
+  def index_output_files
+    [ find_stdout_file, find_stderr_file ].compact
+  end
+
   def find_stdout_file
     JobFile.find("#{id}.stdout", user: user)
   end

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -623,6 +623,30 @@ Content-Type: application/vnd.api+json
 }
 ```
 
+## GET - /jobs/:id/output-files
+
+Return the related output `files` for the `job` that is `stdout` and `stderr`.
+
+```
+GET /v0/jobs/:id/output-files
+Authorization: basic <base64 username:password>
+Accept: application/vnd.api+json
+
+HTTP/2 200 OK
+Content-Type: application/vnd.api+json
+{
+  "data": [
+    FileResource,
+    ...
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "included": [
+  ]
+}
+```
+
 ## GET - /jobs/:id/stdout-file
 
 Return the related `stdout` for the `job`.

--- a/client/src/JobOutputsCard.js
+++ b/client/src/JobOutputsCard.js
@@ -19,7 +19,7 @@ import {
   useFetchResultFiles,
   useFetchFileContent,
 } from './api';
-
+import { useInterval } from './utils';
 
 export function getResourceFromResponse(data) {
   if (!utils.isObject(data)) { return null; }
@@ -125,7 +125,8 @@ function FileItem({ file, isSelected, name, nameTag="span", toggleFile }) {
 }
 
 function OutputListingAsync({ className, isSelected, job, toggleFile }) {
-  const { data, error, loading } = useFetchOutputFiles(job.id);
+  const { data, error, loading, get } = useFetchOutputFiles(job.id);
+  useInterval(get, 1 * 60 * 1000);
 
   if (error) {
     return (
@@ -195,7 +196,8 @@ function OutputListing({ className, isSelected, job, files, toggleFile }) {
 }
 
 function ResultsListingAsync({ className, isSelected, job, toggleFile }) {
-  const { data, error, loading } = useFetchResultFiles(job.id);
+  const { data, error, loading, get } = useFetchResultFiles(job.id);
+  useInterval(get, 1 * 60 * 1000);
 
   if (error) {
     <div className={className}>

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -281,30 +281,20 @@ export function useFetchJob(id) {
     [ currentUser.authToken ]);
 }
 
+export function useFetchOutputFiles(id) {
+  const { currentUser } = useContext(CurrentUserContext);
+  return useFetch(
+    `/jobs/${id}/output-files`,
+    {
+      headers: { Accept: 'application/vnd.api+json' },
+    },
+    [ currentUser.authToken, id ]);
+}
+
 export function useFetchResultFiles(id) {
   const { currentUser } = useContext(CurrentUserContext);
   return useFetch(
     `/jobs/${id}/result-files`,
-    {
-      headers: { Accept: 'application/vnd.api+json' },
-    },
-    [ currentUser.authToken, id ]);
-}
-
-export function useFetchStdoutFile(id) {
-  const { currentUser } = useContext(CurrentUserContext);
-  return useFetch(
-    `/jobs/${id}/stdout-file`,
-    {
-      headers: { Accept: 'application/vnd.api+json' },
-    },
-    [ currentUser.authToken, id ]);
-}
-
-export function useFetchStderrFile(id) {
-  const { currentUser } = useContext(CurrentUserContext);
-  return useFetch(
-    `/jobs/${id}/stderr-file`,
     {
       headers: { Accept: 'application/vnd.api+json' },
     },

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -266,7 +266,7 @@ export function useFetchJobs() {
 export function useFetchJob(id) {
   const { currentUser } = useContext(CurrentUserContext);
   return useFetch(
-    `/jobs/${id}?include=script,resultFiles,stdoutFile,stderrFile`,
+    `/jobs/${id}?include=script`,
     {
       headers: { Accept: 'application/vnd.api+json' },
       interceptors: {
@@ -281,13 +281,42 @@ export function useFetchJob(id) {
     [ currentUser.authToken ]);
 }
 
+export function useFetchResultFiles(id) {
+  const { currentUser } = useContext(CurrentUserContext);
+  return useFetch(
+    `/jobs/${id}/result-files`,
+    {
+      headers: { Accept: 'application/vnd.api+json' },
+    },
+    [ currentUser.authToken, id ]);
+}
+
+export function useFetchStdoutFile(id) {
+  const { currentUser } = useContext(CurrentUserContext);
+  return useFetch(
+    `/jobs/${id}/stdout-file`,
+    {
+      headers: { Accept: 'application/vnd.api+json' },
+    },
+    [ currentUser.authToken, id ]);
+}
+
+export function useFetchStderrFile(id) {
+  const { currentUser } = useContext(CurrentUserContext);
+  return useFetch(
+    `/jobs/${id}/stderr-file`,
+    {
+      headers: { Accept: 'application/vnd.api+json' },
+    },
+    [ currentUser.authToken, id ]);
+}
+
 export function useFetchFileContent(file) {
   const { currentUser } = useContext(CurrentUserContext);
   return useFetch(
     `/${file.type}/${file.id}?fields[files]=payload`,
     {
       headers: { Accept: 'application/vnd.api+json' },
-      // cachePolicy: 'no-cache',
     },
     [ currentUser.authToken, file.id ]);
 }


### PR DESCRIPTION
There is a new route `GET /jobs/<ID/output-files` similar to `GET /jobs/<ID>/result-files` but returning the job's stdout and stderr files.

The job page now has a reduced include list on the job resource.  This reduces the time to get something displayed to the user.  The job's output and results listing are loaded once the job resource has been retrieved.  The output and results are periodically reloaded.


![image](https://user-images.githubusercontent.com/287050/120021558-1ffba900-bfe3-11eb-9871-44cf10122c80.png)
