### PR TITLE
Read system command buffers on the fly

### DIFF
--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -47,7 +47,7 @@ class JobFile
 
       # Error if the system command otherwise failed
       unless cmd.exitstatus == 0
-        raise CommandError, "Failed to load the result files for job: #{job_id}"
+        raise FlightJobScriptAPI::CommandError, "Failed to load the result files for job: #{job_id}"
       end
 
       # Construct the files

--- a/api/lib/flight_job_script_api/configuration.rb
+++ b/api/lib/flight_job_script_api/configuration.rb
@@ -85,9 +85,5 @@ module FlightJobScriptAPI
     def auth_decoder
       @auth_decoder ||= FlightAuth::Builder.new(shared_secret_path)
     end
-
-    def command_timeout_step
-      @command_timeout_step ||= command_timeout / 1000.to_f
-    end
   end
 end

--- a/api/lib/flight_job_script_api/configuration.rb
+++ b/api/lib/flight_job_script_api/configuration.rb
@@ -67,7 +67,8 @@ module FlightJobScriptAPI
       {
         name: 'command_timeout',
         env_var: true,
-        default: 5
+        default: 5,
+        transform: :to_f
       },
       {
         name: 'log_level',
@@ -83,6 +84,10 @@ module FlightJobScriptAPI
 
     def auth_decoder
       @auth_decoder ||= FlightAuth::Builder.new(shared_secret_path)
+    end
+
+    def command_timeout_step
+      @command_timeout_step ||= command_timeout / 1000.to_f
     end
   end
 end

--- a/api/lib/flight_job_script_api/system_command.rb
+++ b/api/lib/flight_job_script_api/system_command.rb
@@ -237,7 +237,7 @@ module FlightJobScriptAPI
           end
         ensure
           # Confirm the threads have naturally finished
-          if @threads.any?(&:alive?)
+          if @threads && @threads.any?(&:alive?)
             FlightJobScriptAPI.logger.error <<~ERROR.chomp
               Failed to read all of stdout/stderr for pid: #{pid}
             ERROR

--- a/api/lib/flight_job_script_api/system_command.rb
+++ b/api/lib/flight_job_script_api/system_command.rb
@@ -159,8 +159,7 @@ module FlightJobScriptAPI
         FlightJobScriptAPI.logger.debug("Forking Process")
         pid = Kernel.fork do
           # Log the command has been forked
-          log_cmd = (cmd.first == :noop ? cmd[1..-1] : cmd).join(' ')
-          FlightJobScriptAPI.logger.info("Forked Command (#{user}): #{log_cmd}")
+          FlightJobScriptAPI.logger.debug("Forked Command (#{user}): #{stringified_cmd}")
 
           # Close the parent pipes
           out_read.close
@@ -187,7 +186,7 @@ module FlightJobScriptAPI
               out: out_write, err: err_write, in: in_read
             }
             # NOTE: Keep the log before the exec for timing purposes
-            FlightJobScriptAPI.logger.info("Executing (#{user}): #{cmd.join(' ')}")
+            FlightJobScriptAPI.logger.debug("Executing (#{user}): #{stringified_cmd}")
             Kernel.exec(env, *cmd, **opts)
           end
         end
@@ -256,6 +255,11 @@ module FlightJobScriptAPI
 
     def passwd
       @passwd ||= Etc.getpwnam(user)
+    end
+
+    def stringified_cmd
+      @stringified_cmd ||= (cmd.first == :noop ? cmd[1..-1] : cmd)
+        .map { |s| s.empty? ? '""' : s }.join(' ')
     end
   end
 end


### PR DESCRIPTION
Moving forward, the `flight job` utility will be returning more data within individual calls. This allows the overall number of commands to be reduced. It does however mean the `stdout` pipe can block the process when it reduces its maximum buffer size.

Instead the `stdout` buffer needs to be read whilst the command is being executed. This means the data will be stored within `ruby` memory which is (assumable?) quite a bit larger. This is done by calling `read_nonblock` on the `stdout` IO. A similar thing is done on `stderr` for consistency.

I have reworked the timeout mechanism so it wouldn't raise `Timeout::TimeoutError` whilst `read_nonblock` is being called. Doing so could lead to some of the data disappearing. Instead it is periodically checked when there is no data available.