### PR TITLE
Use the underlying CLI --include flag

### DIFF
--- a/api/app.rb
+++ b/api/app.rb
@@ -234,8 +234,18 @@ class App < Sinatra::Base
     end
 
     has_one :script do
+      helpers do
+        # XXX: The 'serialize_linkage' method gets called on sideloads before its
+        # result is discarded. However it is in-inadvertently triggering a SystemCommand
+        def serialize_linkage(**_)
+          return {} if @action == :create
+          super
+        end
+      end
+
       graft(sideload_on: :create) do |rio|
         raise Sinja::ForbiddenError, "A job's script can not be modified" unless @action == :create
+
         resource.script_id = rio[:id]
       end
     end

--- a/api/app.rb
+++ b/api/app.rb
@@ -74,10 +74,6 @@ class App < Sinatra::Base
       end
     end
 
-    def includes?(resource_name)
-      ( params['include'] || [] ).include?(resource_name)
-    end
-
     def include_string
       case params.fetch('include', nil)
       when String
@@ -235,7 +231,7 @@ class App < Sinatra::Base
 
     has_one :script do
       helpers do
-        # XXX: The 'serialize_linkage' method gets called on sideloads before its
+        # NOTE: The 'serialize_linkage' method gets called on sideloads before its
         # result is discarded. However it is in-inadvertently triggering a SystemCommand
         def serialize_linkage(**_)
           return {} if @action == :create

--- a/api/app.rb
+++ b/api/app.rb
@@ -158,8 +158,7 @@ class App < Sinatra::Base
     end
 
     index do
-      Template.index(user: current_user) if includes?('template')
-      Script.index(user: current_user)
+      Script.index(user: current_user, include: include_string)
     end
 
     show

--- a/api/app.rb
+++ b/api/app.rb
@@ -153,7 +153,7 @@ class App < Sinatra::Base
   resource :scripts, pkre: /[\w-]+/ do
     helpers do
       def find(id)
-        Script.find!(id, user: current_user)
+        Script.find!(id, user: current_user, include: include_string)
       end
     end
 

--- a/api/app.rb
+++ b/api/app.rb
@@ -78,8 +78,15 @@ class App < Sinatra::Base
       ( params['include'] || [] ).include?(resource_name)
     end
 
-    def include_param
-      params.fetch('include', '')
+    def include_string
+      case params.fetch('include')
+      when String
+        params.fetch('include')
+      when Array
+        params.fetch('include').join(',')
+      else
+        ''
+      end
     end
   end
 
@@ -201,7 +208,7 @@ class App < Sinatra::Base
   resource :jobs, pkre: /[\w-]+/ do
     helpers do
       def find(id)
-        Job.find!(id, user: current_user, include: include_param)
+        Job.find!(id, user: current_user, include: include_string)
       end
 
       def validate!
@@ -214,8 +221,7 @@ class App < Sinatra::Base
     end
 
     index do
-      Script.index(user: current_user) if includes?('script')
-      Job.index(user: current_user)
+      Job.index(user: current_user, include: include_string)
     end
 
     show

--- a/api/app.rb
+++ b/api/app.rb
@@ -207,7 +207,8 @@ class App < Sinatra::Base
   resource :jobs, pkre: /[\w-]+/ do
     helpers do
       def find(id)
-        Job.find!(id, user: current_user, include: include_string)
+        j = Job.find!(id, user: current_user, include: include_string)
+        j ? j : nil
       end
 
       def validate!

--- a/api/app.rb
+++ b/api/app.rb
@@ -79,7 +79,7 @@ class App < Sinatra::Base
     end
 
     def include_string
-      case params.fetch('include')
+      case params.fetch('include', nil)
       when String
         params.fetch('include').underscore
       when Array

--- a/api/app.rb
+++ b/api/app.rb
@@ -81,9 +81,9 @@ class App < Sinatra::Base
     def include_string
       case params.fetch('include')
       when String
-        params.fetch('include')
+        params.fetch('include').underscore
       when Array
-        params.fetch('include').join(',')
+        params.fetch('include').map(&:underscore).join(',')
       else
         ''
       end

--- a/api/app.rb
+++ b/api/app.rb
@@ -207,8 +207,7 @@ class App < Sinatra::Base
   resource :jobs, pkre: /[\w-]+/ do
     helpers do
       def find(id)
-        j = Job.find!(id, user: current_user, include: include_string)
-        j ? j : nil
+        Job.find!(id, user: current_user, include: include_string)
       end
 
       def validate!

--- a/api/app.rb
+++ b/api/app.rb
@@ -77,6 +77,10 @@ class App < Sinatra::Base
     def includes?(resource_name)
       ( params['include'] || [] ).include?(resource_name)
     end
+
+    def include_param
+      params.fetch('include', '')
+    end
   end
 
   configure_jsonapi do |c|
@@ -197,7 +201,7 @@ class App < Sinatra::Base
   resource :jobs, pkre: /[\w-]+/ do
     helpers do
       def find(id)
-        Job.find!(id, user: current_user)
+        Job.find!(id, user: current_user, include: include_param)
       end
 
       def validate!

--- a/api/app/models/job.rb
+++ b/api/app/models/job.rb
@@ -116,11 +116,18 @@ class Job
     [ find_stdout_file, find_stderr_file ].compact
   end
 
+  def stderr_merged?
+    paths = metadata.slice('stdout_path', 'stderr_path').values.uniq
+    return nil if paths.length == 1 && paths.first.nil?
+    paths.length == 1
+  end
+
   def find_stdout_file
     JobFile.find("#{id}.stdout", user: user)
   end
 
   def find_stderr_file
+    return nil if stderr_merged?
     JobFile.find("#{id}.stderr", user: user)
   end
 

--- a/api/app/models/job.rb
+++ b/api/app/models/job.rb
@@ -141,5 +141,15 @@ class Job
         JobFile.cache(id, file_id, user: user, size: size)
       end
     end
+
+    # NOTE: This pre-populates the stdout/stderr files in the cache
+    # and bypasses the existence check on 'find'
+    if stdout_size = metadata['stdout_size']
+      JobFile.cache(id, 'stdout', user: user, size: stdout_size)
+    end
+
+    if stderr_size = metadata['stderr_size']
+      JobFile.cache(id, 'stderr', user: user, size: stderr_size)
+    end
   end
 end

--- a/api/app/models/job.rb
+++ b/api/app/models/job.rb
@@ -151,7 +151,7 @@ class Job
       JobFile.cache(id, 'stdout', user: user, size: stdout_size)
     end
 
-    if stderr_size = metadata['stderr_size']
+    if !stderr_merged? && stderr_size = metadata['stderr_size']
       JobFile.cache(id, 'stderr', user: user, size: stderr_size)
     end
   end

--- a/api/app/models/job.rb
+++ b/api/app/models/job.rb
@@ -67,8 +67,6 @@ class Job
 
     # Flag that the script has not been loaded
     @script = false
-
-    cache_related_resources
   end
 
   def id
@@ -125,8 +123,6 @@ class Job
   def find_stderr_file
     JobFile.find("#{id}.stderr", user: user)
   end
-
-  private
 
   def cache_related_resources
     if script_data = metadata['script']

--- a/api/app/models/job.rb
+++ b/api/app/models/job.rb
@@ -67,6 +67,8 @@ class Job
 
     # Flag that the script has not been loaded
     @script = false
+
+    cache_related_resources
   end
 
   def id
@@ -122,5 +124,13 @@ class Job
 
   def find_stderr_file
     JobFile.find("#{id}.stderr", user: user)
+  end
+
+  private
+
+  def cache_related_resources
+    if script_data = metadata['script']
+      Script.cache(user: user, **script_data)
+    end
   end
 end

--- a/api/app/models/job.rb
+++ b/api/app/models/job.rb
@@ -57,6 +57,10 @@ class Job
 
       new(user: opts[:user], **cmd.stdout)
     end
+
+    def cache(**opts)
+      new(**opts)
+    end
   end
 
   attr_reader :metadata, :user

--- a/api/app/models/job.rb
+++ b/api/app/models/job.rb
@@ -57,10 +57,6 @@ class Job
 
       new(user: opts[:user], **cmd.stdout)
     end
-
-    def cache(**opts)
-      new(**opts)
-    end
   end
 
   attr_reader :metadata, :user
@@ -135,6 +131,15 @@ class Job
   def cache_related_resources
     if script_data = metadata['script']
       Script.cache(user: user, **script_data)
+    end
+
+    if files_data = metadata['result_files']
+      files_data.each do |opts|
+        file = opts['file']
+        size = opts['size']
+        file_id = JobFile.generate_file_id(metadata['results_dir'], file)
+        JobFile.cache(id, file_id, user: user, size: size)
+      end
     end
   end
 end

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -41,24 +41,9 @@ class JobFile
     #       Consider refactoring
     def index_job_results!(job_id, user:)
       # Attempt to load the cached version of Job
-      job = Job.find!(job_id, user: user, include: ['result_files'])
+      job = Job.find!(job_id, user: user)
 
-      # NOTE: If the Job is pre-cached, it must be loaded with --include result_files
-      # This *should* already be the case due to the 'includes' mechanism
-      # Revisit if required
-      unless job.metadata.key? 'result_files'
-        FlightJobScriptAPI.logger.error <<~ERROR.chomp
-          The job '#{job_id}' was unexpectedly loaded without its results_files
-        ERROR
-        raise FlightJobScriptAPI::CommandError, "Failed to load the results files for job: #{job_id}"
-      end
-
-      # Fetch the pre-cached files
-      # NOTE: 'result_files' maybe nil if results_dir was missing OR not reported
-      #       The exact API specification is "unclear" for these situations
-      #
-      #       It's being typed-casted to an array here for consistency. Possible the
-      #       serializer is the best place to enforce the spec?
+      # Fetch the files
       (job.metadata['result_files'] || []).map do |data|
         # NOTE: 'results_dir' must be set otherwise the files would be empty
         file_id = generate_file_id(job.metadata['results_dir'], data['file'])

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -188,8 +188,8 @@ class JobFile
   # `flight job` command
   def is_readable?(id, path)
     logger = FlightJobScriptAPI.logger
-    logger.debug("Checking file is readable: path:#{path.inspect}; user:#{@user.inspect}")
-    sp = Subprocess.new(
+    logger.debug("Checking file is readable: id:#{id.inspect} path:#{path.inspect} user:#{@user.inspect}")
+    sp = FlightJobScriptAPI::Subprocess.new(
       env: {},
       logger: logger,
       timeout: FlightJobScriptAPI.config.command_timeout,
@@ -199,7 +199,7 @@ class JobFile
       exit(20) unless File.exists?(path)
       File.stat(path).readable? ? exit(0) : exit(20)
     end
-    logger.debug("Checked file is readable: path:#{path.inspect}; user:#{@user.inspect}; exitstatus:#{result.exitstatus}; pid=#{result.pid}")
+    logger.debug("Checked file is readable: id:#{id.inspect} path:#{path.inspect} user:#{@user.inspect} exitstatus:#{result.exitstatus}; pid=#{result.pid}")
     case result.exitstatus
     when 0
       true

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -122,12 +122,11 @@ class JobFile
 
   # Checks the file exists and the user has permission to access it
   def exists?
-    return @exists unless @exists.nil?
-    return @exists = false unless path
-    return @exists = false unless File.exists?(path)
+    return false unless path
+    return false unless File.exists?(path)
     # NOTE: The permission check prevents malicious user's querying the
     # filesystem.
-    @exists = is_readable?(id, path)
+    is_readable?(id, path)
   end
 
   def find_job

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -192,6 +192,7 @@ class JobFile
       username: @user,
     )
     result = sp.run(nil, nil) do
+      exit(20) unless File.exists?(path)
       File.stat(path).readable? ? exit(0) : exit(20)
     end
     case result.exitstatus

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -32,6 +32,10 @@ class JobFile
   class << self
     prepend FlightJobScriptAPI::ModelCache
 
+    def generate_file_id(results_dir, file_path)
+      Base64.urlsafe_encode64 Pathname.new(file_path).relative_path_from(results_dir).to_s
+    end
+
     def index_job_results!(job_id, user:)
       # Load up the job
       job = Job.find!(job_id, user: user)
@@ -54,7 +58,7 @@ class JobFile
       JSON.parse(cmd.stdout).map do |payload|
         file = payload['file']
         size = payload['size']
-        file_id = Base64.urlsafe_encode64 Pathname.new(file).relative_path_from(results_dir).to_s
+        file_id = generate_file_id(results_dir, file)
         JobFile.new(job.id, file_id, user: user, size: size)
       end
     end

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -105,6 +105,8 @@ class JobFile
   end
 
   # Checks the file exists and the user has permission to access it
+  #
+  # NOTE: This method may raise CommandError.
   def exists?
     return false unless path
     return false unless File.exists?(path)

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -112,7 +112,7 @@ class JobFile
     return false unless File.exists?(path)
     # NOTE: The permission check prevents malicious user's querying the
     # filesystem.
-    is_readable?(id, path)
+    is_readable?
   end
 
   def find_job
@@ -186,7 +186,7 @@ class JobFile
   #
   # We directly check the file permissions here to avoid launching a new
   # `flight job` command
-  def is_readable?(id, path)
+  def is_readable?
     logger = FlightJobScriptAPI.logger
     logger.debug("Checking file is readable: id:#{id.inspect} path:#{path.inspect} user:#{@user.inspect}")
     sp = FlightJobScriptAPI::Subprocess.new(

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -76,8 +76,7 @@ class JobFile
     def find!(id, **opts)
       job_id, file_id = id.split('.', 2)
       new(job_id, file_id, user: opts[:user]).tap do |job_file|
-        # NOTE: Intentionally cache 'false' if the file doesn't exist
-        return false unless job_file.exists?
+        return nil unless job_file.exists?
       end
     end
 

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -187,9 +187,11 @@ class JobFile
   # We directly check the file permissions here to avoid launching a new
   # `flight job` command
   def is_readable?(id, path)
+    logger = FlightJobScriptAPI.logger
+    logger.debug("Checking file is readable: path:#{path.inspect}; user:#{@user.inspect}")
     sp = Subprocess.new(
       env: {},
-      logger: FlightJobScriptAPI.logger,
+      logger: logger,
       timeout: FlightJobScriptAPI.config.command_timeout,
       username: @user,
     )
@@ -197,6 +199,7 @@ class JobFile
       exit(20) unless File.exists?(path)
       File.stat(path).readable? ? exit(0) : exit(20)
     end
+    logger.debug("Checked file is readable: path:#{path.inspect}; user:#{@user.inspect}; exitstatus:#{result.exitstatus}; pid=#{result.pid}")
     case result.exitstatus
     when 0
       true

--- a/api/app/models/script.rb
+++ b/api/app/models/script.rb
@@ -65,9 +65,6 @@ class Script
 
     # Flag that the template has not been loaded
     @template = false
-
-    # Cache the related resources
-    cache_related_resources
   end
 
   def id
@@ -97,8 +94,6 @@ class Script
   def find_note
     ScriptNote.find(id, user: user)
   end
-
-  private
 
   def cache_related_resources
     if template_data = metadata['template']

--- a/api/app/models/script.rb
+++ b/api/app/models/script.rb
@@ -55,10 +55,6 @@ class Script
 
       new(user: opts[:user], **cmd.stdout)
     end
-
-    def cache(**options)
-      new(**options)
-    end
   end
 
   attr_reader :metadata, :user

--- a/api/app/models/script.rb
+++ b/api/app/models/script.rb
@@ -55,6 +55,10 @@ class Script
 
       new(user: opts[:user], **cmd.stdout)
     end
+
+    def cache(**options)
+      new(**options)
+    end
   end
 
   attr_reader :metadata, :user

--- a/api/app/models/script.rb
+++ b/api/app/models/script.rb
@@ -69,6 +69,9 @@ class Script
 
     # Flag that the template has not been loaded
     @template = false
+
+    # Cache the related resources
+    cache_related_resources
   end
 
   def id
@@ -97,5 +100,13 @@ class Script
 
   def find_note
     ScriptNote.find(id, user: user)
+  end
+
+  private
+
+  def cache_related_resources
+    if template_data = metadata['template']
+      Template.cache(**template_data)
+    end
   end
 end

--- a/api/app/models/template.rb
+++ b/api/app/models/template.rb
@@ -47,7 +47,7 @@ class Template
     end
 
     def find!(id, **opts)
-      # The underlying CLI has supports non-deterministic indexing of templates
+      # The underlying CLI supports non-deterministic indexing of templates
       # This "okay" in the CLI but makes the API unnecessarily complicated
       # Instead, all "ids" which match an integer will be ignored
       # NOTE: This means templates which are named after an integer may be indexed

--- a/api/app/models/template.rb
+++ b/api/app/models/template.rb
@@ -63,10 +63,6 @@ class Template
 
       new(**cmd.stdout)
     end
-
-    def cache(**opts)
-      new(**opts)
-    end
   end
 
   attr_reader :metadata

--- a/api/app/models/template.rb
+++ b/api/app/models/template.rb
@@ -63,6 +63,10 @@ class Template
 
       new(**cmd.stdout)
     end
+
+    def cache(**opts)
+      new(**opts)
+    end
   end
 
   attr_reader :metadata

--- a/api/app/serializers/job_serializer.rb
+++ b/api/app/serializers/job_serializer.rb
@@ -37,12 +37,7 @@ class JobSerializer < ApplicationSerializer
 
   attribute(:start_time) { object.metadata['actual_start_time'] }
   attribute(:end_time) { object.metadata['actual_end_time'] }
-
-  attribute(:merged_stderr) do
-    paths = object.metadata.slice('stdout_path', 'stderr_path').values.uniq
-    return nil if paths.length == 1 && paths.first.nil?
-    paths.length == 1
-  end
+  attribute(:merged_stderr) { object.stderr_merged? }
 
   has_one :script
   has_one(:stdout_file) { object.find_stdout_file }

--- a/api/lib/flight_job_script_api/job_cli.rb
+++ b/api/lib/flight_job_script_api/job_cli.rb
@@ -123,18 +123,6 @@ module FlightJobScriptAPI
         new(*flight_job, 'submit-job', script_id, '--json', *includes, **opts).run
       end
 
-      def view_job_stdout(job_id, **opts)
-        new(*flight_job, 'view-job-stdout', job_id, **opts).run
-      end
-
-      def view_job_stderr(job_id, **opts)
-        new(*flight_job, 'view-job-stderr', job_id, **opts).run
-      end
-
-      def view_job_results(job_id, filename, **opts)
-        new(*flight_job, 'view-job-results', job_id, filename, **opts).run
-      end
-
       private
 
       def flight_job

--- a/api/lib/flight_job_script_api/job_cli.rb
+++ b/api/lib/flight_job_script_api/job_cli.rb
@@ -43,19 +43,27 @@ module FlightJobScriptAPI
       end
 
       def list_templates(**opts)
-        new(*flight_job, 'list-templates', '--json', **opts).run
+        opts = opts.dup
+        includes = opts.key?(:include) ? ["--include", opts.delete(:include)] : []
+        new(*flight_job, 'list-templates', '--json', *includes, **opts).run
       end
 
       def info_template(id, **opts)
-        new(*flight_job, 'info-template', id, '--json', **opts).run
+        opts = opts.dup
+        includes = opts.key?(:include) ? ["--include", opts.delete(:include)] : []
+        new(*flight_job, 'info-template', id, '--json', *includes, **opts).run
       end
 
       def list_scripts(**opts)
-        new(*flight_job, 'list-scripts', '--json', **opts).run
+        opts = opts.dup
+        includes = opts.key?(:include) ? ["--include", opts.delete(:include)] : []
+        new(*flight_job, 'list-scripts', '--json', *includes, **opts).run
       end
 
       def info_script(id, **opts)
-        new(*flight_job, 'info-script', id, '--json', **opts).run
+        opts = opts.dup
+        includes = opts.key?(:include) ? ["--include", opts.delete(:include)] : []
+        new(*flight_job, 'info-script', id, '--json', *includes, **opts).run
       end
 
       def create_script(template_id, name = nil, answers: nil, notes: nil, **opts)
@@ -67,7 +75,9 @@ module FlightJobScriptAPI
         args = name ? [template_id, name] : [template_id]
         args.push('--answers', "@#{answers_path}") if answers
         args.push('--notes', "@#{notes_path}") if notes
-        sys = new(*flight_job, 'create-script', *args, '--json', **opts)
+        opts = opts.dup
+        includes = opts.key?(:include) ? ["--include", opts.delete(:include)] : []
+        sys = new(*flight_job, 'create-script', *args, '--json', *includes, **opts)
         sys.run do
           File.write answers_path, answers if answers
           File.write notes_path, notes if notes
@@ -78,27 +88,39 @@ module FlightJobScriptAPI
       end
 
       def edit_script_notes(script_id, **opts)
-        new(*flight_job, 'edit-script-notes', script_id, '--json', '--notes', '@-', **opts).run
+        opts = opts.dup
+        includes = opts.key?(:include) ? ["--include", opts.delete(:include)] : []
+        new(*flight_job, 'edit-script-notes', script_id, '--json', '--notes', '@-', *includes, **opts).run
       end
 
       def edit_script(script_id, **opts)
-        new(*flight_job, 'edit-script', script_id, '--json', '--force', '--content', '@-', **opts).run
+        opts = opts.dup
+        includes = opts.key?(:include) ? ["--include", opts.delete(:include)] : []
+        new(*flight_job, 'edit-script', script_id, '--json', '--force', '--content', '@-', *includes, **opts).run
       end
 
       def delete_script(id, **opts)
-        new(*flight_job, 'delete-script', id, '--json',**opts).run
+        opts = opts.dup
+        includes = opts.key?(:include) ? ["--include", opts.delete(:include)] : []
+        new(*flight_job, 'delete-script', id, '--json', *includes, **opts).run
       end
 
       def list_jobs(**opts)
-        new(*flight_job, 'list-jobs', '--json', **opts).run
+        opts = opts.dup
+        includes = opts.key?(:include) ? ["--include", opts.delete(:include)] : []
+        new(*flight_job, 'list-jobs', '--json', *includes, **opts).run
       end
 
       def info_job(id, **opts)
-        new(*flight_job, 'info-job', id, '--json', **opts).run
+        opts = opts.dup
+        includes = opts.key?(:include) ? ["--include", opts.delete(:include)] : []
+        new(*flight_job, 'info-job', id, '--json', *includes, **opts).run
       end
 
       def submit_job(script_id, **opts)
-        new(*flight_job, 'submit-job', script_id, '--json', **opts).run
+        opts = opts.dup
+        includes = opts.key?(:include) ? ["--include", opts.delete(:include)] : []
+        new(*flight_job, 'submit-job', script_id, '--json', *includes, **opts).run
       end
 
       def view_job_stdout(job_id, **opts)

--- a/api/lib/flight_job_script_api/model_cache.rb
+++ b/api/lib/flight_job_script_api/model_cache.rb
@@ -43,14 +43,16 @@ module FlightJobScriptAPI::ModelCache
     end
   end
 
-  def cache(**opts)
-    id = opts['id']
+  def cache(*args, **opts)
+    model = new(*args, **opts)
+    id = model.id
     if record = get_from_cache(id)
       # NOTE: Records are not re-cached as it may cause duplicate resources
       # when loading many-to-one relationships
       record
     else
-      super.tap { |r| set_in_cache(id, r) }
+      set_in_cache(id, model)
+      model
     end
   end
 

--- a/api/lib/flight_job_script_api/model_cache.rb
+++ b/api/lib/flight_job_script_api/model_cache.rb
@@ -43,6 +43,17 @@ module FlightJobScriptAPI::ModelCache
     end
   end
 
+  def cache(**opts)
+    id = opts['id']
+    if record = get_from_cache(id)
+      # NOTE: Records are not re-cached as it may cause duplicate resources
+      # when loading many-to-one relationships
+      record
+    else
+      super.tap { |r| set_in_cache(id, r) }
+    end
+  end
+
   private
 
   # NOTE: The 'id' is unique on a per user basis instead of globally. This works

--- a/api/lib/flight_job_script_api/model_cache.rb
+++ b/api/lib/flight_job_script_api/model_cache.rb
@@ -31,6 +31,7 @@ module FlightJobScriptAPI::ModelCache
     super.tap do |records|
       records.each do |record|
         set_in_cache(record.id, record)
+        record.cache_related_resources if record.respond_to?(:cache_related_resources)
       end
     end
   end
@@ -40,6 +41,7 @@ module FlightJobScriptAPI::ModelCache
     return record unless record.nil?
     super.tap do |record|
       set_in_cache(id, record) unless record.nil?
+      record.cache_related_resources if record.respond_to?(:cache_related_resources)
     end
   end
 
@@ -52,6 +54,7 @@ module FlightJobScriptAPI::ModelCache
       record
     else
       set_in_cache(id, model)
+      model.cache_related_resources if model.respond_to?(:cache_related_resources)
       model
     end
   end


### PR DESCRIPTION
The `index`/`show` routes for `jobs` and `scripts` now support an "enhanced" version of `include`.

The `include` query parameter is now passed to the CLI as an `--include` flag. The CLI will ignore unrecognised includes as they are too be expected. The keys are converted from CamalCase to snake_case, but our otherwise compatible.

The additional included data will be stored in the respective models `metadata`. This data will be converted to a related resource and cached by the `ModelCache`. This replaces the existing "pre-warming" mechanism.

---

The `resultFiles` are a supported include for job(s). This will trigger `flight-job` to return a list of `results_files` and their corresponding size in the metadata. It is safe to assume they all exist and can be directly cached.

This mechanism completely replaces the `recursive_glob_dir` which I found to be slow and flaky on (**):
`GET /jobs?include=resultFiles`

** For some reason `ruby` struggles to `fork` when called in rapid succession. I couldn't exactly determine why, but decided it was better to cut down on the calls instead.

---

`flight job` will now return the `size` of the included `result_files` as well as `stdout_size` and `stderr_size`. This makes it possible to serialize the `JobFile` resources' metadata without loading the file.

This provides a speed benefit as "reading the file" (**) needs to be done as the user. This ensures the file permissions are obeyed by `flight-job-script-api`. It does however lead to additional system commands and overhead.

Pre-caching side steps this problem as the files must exist, should have the correct file permissions, and contains the relevant metadata for the serializer.

** Technically only the file permissions are checked as the relevant user. The file is read by the main process directly to avoid unnecessary read/writes to a pipe. This file permission check is always preformed before loading the file.