### PR TITLE
Fix writing to STDIN within the SystemCommand

### DIFF
--- a/api/lib/flight_job_script_api/system_command.rb
+++ b/api/lib/flight_job_script_api/system_command.rb
@@ -192,9 +192,6 @@ module FlightJobScriptAPI
     def with_fork(&block)
       self.class.mutexes[user].synchronize do
         begin
-          # Flag the start time
-          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
           # Create the pipes
           @out_read,  @out_write = IO.pipe
           @err_read,  @err_write = IO.pipe
@@ -216,6 +213,9 @@ module FlightJobScriptAPI
           #       The large 'notes'/'answer' inputs are already "passed by file"
           #       Consider refactoring if it causes an issue
           @in_write.write(stdin) if stdin
+
+          # Flag the start time
+          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
           # Fork the child process
           FlightJobScriptAPI.logger.debug("Forking Process")

--- a/api/lib/flight_job_script_api/system_command.rb
+++ b/api/lib/flight_job_script_api/system_command.rb
@@ -215,7 +215,7 @@ module FlightJobScriptAPI
           # NOTE: This could *technically* block if stdin exceeds ~60KiB (system dependent)
           #       The large 'notes'/'answer' inputs are already "passed by file"
           #       Consider refactoring if it causes an issue
-          in_write.write(stdin) if stdin
+          @in_write.write(stdin) if stdin
 
           # Fork the child process
           FlightJobScriptAPI.logger.debug("Forking Process")

--- a/api/lib/flight_job_script_api/system_command.rb
+++ b/api/lib/flight_job_script_api/system_command.rb
@@ -179,6 +179,8 @@ module FlightJobScriptAPI
           Kernel.exec(env, *cmd, **opts)
         end
       end
+    ensure
+      log_command
     end
 
     private
@@ -262,8 +264,6 @@ module FlightJobScriptAPI
               ERROR
             end
           end
-
-          log_command
         end
       end
     end


### PR DESCRIPTION
It was still writing to the original accessor method `in_write` instead of the instance variable `@in_write`.

This caused a `nil` error in the `ensure` block which prevented the logger from running. The logging has now been moved to a higher `ensure` block.

The `start` timer has been moved to after `STDIN` is ready, but before the `fork`.