### PR TITLE
Fix script and note editing; refactor subprocess creation

### DIFF
--- a/api/app.rb
+++ b/api/app.rb
@@ -332,7 +332,7 @@ class RenderApp < Sinatra::Base
     # Either way, the 'job' resource was created
     if [0, 2].include?(cmd.exitstatus)
       response.headers['Content-Type'] = 'application/vnd.api+json'
-      script = Script.new(user: @current_user, **JSON.parse(cmd.stdout))
+      script = Script.new(user: @current_user, **cmd.stdout)
       status 201
       next JSONAPI::Serializer.serialize(script).to_json
 

--- a/api/app.rb
+++ b/api/app.rb
@@ -324,7 +324,7 @@ class RenderApp < Sinatra::Base
     notes = params['notes'].to_s
     notes = nil if notes.empty?
     answers = params['answers'].dup.to_json
-    cmd = FlightJobScriptAPI::SystemCommand.flight_create_script(
+    cmd = FlightJobScriptAPI::SystemCommand.create_script(
       params[:id], name, notes: notes, answers: answers, user: @current_user
     )
 

--- a/api/app.rb
+++ b/api/app.rb
@@ -324,7 +324,7 @@ class RenderApp < Sinatra::Base
     notes = params['notes'].to_s
     notes = nil if notes.empty?
     answers = params['answers'].dup.to_json
-    cmd = FlightJobScriptAPI::SystemCommand.create_script(
+    cmd = FlightJobScriptAPI::JobCLI.create_script(
       params[:id], name, notes: notes, answers: answers, user: @current_user
     )
 

--- a/api/app/models/job.rb
+++ b/api/app/models/job.rb
@@ -37,7 +37,7 @@ class Job
         next if cmd.exitstatus == 0
         raise FlightJobScriptAPI::CommandError, 'Unexpectedly failed to list jobs'
       end
-      JSON.parse(cmd.stdout).map do |metadata|
+      cmd.stdout.map do |metadata|
         new(user: opts[:user], **metadata)
       end
     end
@@ -55,7 +55,7 @@ class Job
         raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to find job: #{id}"
       end
 
-      new(user: opts[:user], **JSON.parse(cmd.stdout))
+      new(user: opts[:user], **cmd.stdout)
     end
   end
 
@@ -105,7 +105,7 @@ class Job
       end
     end
 
-    @metadata = JSON.parse(cmd.stdout)
+    @metadata = cmd.stdout
   end
 
   def index_result_files

--- a/api/app/models/job.rb
+++ b/api/app/models/job.rb
@@ -33,7 +33,7 @@ class Job
     prepend FlightJobScriptAPI::ModelCache
 
     def index(**opts)
-      cmd = FlightJobScriptAPI::SystemCommand.flight_list_jobs(**opts).tap do |cmd|
+      cmd = FlightJobScriptAPI::SystemCommand.list_jobs(**opts).tap do |cmd|
         next if cmd.exitstatus == 0
         raise FlightJobScriptAPI::CommandError, 'Unexpectedly failed to list jobs'
       end
@@ -49,7 +49,7 @@ class Job
     end
 
     def find!(id, **opts)
-      cmd = FlightJobScriptAPI::SystemCommand.flight_info_job(id, **opts).tap do |cmd|
+      cmd = FlightJobScriptAPI::SystemCommand.info_job(id, **opts).tap do |cmd|
         next if cmd.exitstatus == 0
         return nil if cmd.exitstatus == 23
         raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to find job: #{id}"
@@ -96,7 +96,7 @@ class Job
       raise MissingScript, "Cannot create a job without a script"
     end
 
-    cmd = FlightJobScriptAPI::SystemCommand.flight_submit_job(script_id, user: user).tap do |cmd|
+    cmd = FlightJobScriptAPI::SystemCommand.submit_job(script_id, user: user).tap do |cmd|
       next if cmd.exitstatus == 0
       if cmd.exitstatus == 22
         raise MissingScript, "Failed to locate script : #{script_id}"

--- a/api/app/models/job.rb
+++ b/api/app/models/job.rb
@@ -33,7 +33,7 @@ class Job
     prepend FlightJobScriptAPI::ModelCache
 
     def index(**opts)
-      cmd = FlightJobScriptAPI::SystemCommand.list_jobs(**opts).tap do |cmd|
+      cmd = FlightJobScriptAPI::JobCLI.list_jobs(**opts).tap do |cmd|
         next if cmd.exitstatus == 0
         raise FlightJobScriptAPI::CommandError, 'Unexpectedly failed to list jobs'
       end
@@ -49,7 +49,7 @@ class Job
     end
 
     def find!(id, **opts)
-      cmd = FlightJobScriptAPI::SystemCommand.info_job(id, **opts).tap do |cmd|
+      cmd = FlightJobScriptAPI::JobCLI.info_job(id, **opts).tap do |cmd|
         next if cmd.exitstatus == 0
         return nil if cmd.exitstatus == 23
         raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to find job: #{id}"
@@ -96,7 +96,7 @@ class Job
       raise MissingScript, "Cannot create a job without a script"
     end
 
-    cmd = FlightJobScriptAPI::SystemCommand.submit_job(script_id, user: user).tap do |cmd|
+    cmd = FlightJobScriptAPI::JobCLI.submit_job(script_id, user: user).tap do |cmd|
       next if cmd.exitstatus == 0
       if cmd.exitstatus == 22
         raise MissingScript, "Failed to locate script : #{script_id}"

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -196,11 +196,11 @@ class JobFile
   def payload_command
     return @payload_command unless @payload_command.nil?
     @payload_command = if @file_id == 'stdout'
-      FlightJobScriptAPI::SystemCommand.flight_view_job_stdout(@job_id, user: @user)
+      FlightJobScriptAPI::SystemCommand.view_job_stdout(@job_id, user: @user)
     elsif @file_id == 'stderr'
-      FlightJobScriptAPI::SystemCommand.flight_view_job_stderr(@job_id, user: @user)
+      FlightJobScriptAPI::SystemCommand.view_job_stderr(@job_id, user: @user)
     elsif decoded_file_id
-      FlightJobScriptAPI::SystemCommand.flight_view_job_results(@job_id, decoded_file_id, user: @user)
+      FlightJobScriptAPI::SystemCommand.view_job_results(@job_id, decoded_file_id, user: @user)
     else
       false
     end

--- a/api/app/models/job_file.rb
+++ b/api/app/models/job_file.rb
@@ -40,7 +40,7 @@ class JobFile
       results_dir = job.metadata['results_dir']
 
       # Find the relevant files
-      cmd = FlightJobScriptAPI::SystemCommand.recursive_glob_dir(results_dir, user: user)
+      cmd = FlightJobScriptAPI::JobCLI.recursive_glob_dir(results_dir, user: user)
 
       # Return empty array if the results directory is missing
       return [] if cmd.exitstatus == 20
@@ -196,11 +196,11 @@ class JobFile
   def payload_command
     return @payload_command unless @payload_command.nil?
     @payload_command = if @file_id == 'stdout'
-      FlightJobScriptAPI::SystemCommand.view_job_stdout(@job_id, user: @user)
+      FlightJobScriptAPI::JobCLI.view_job_stdout(@job_id, user: @user)
     elsif @file_id == 'stderr'
-      FlightJobScriptAPI::SystemCommand.view_job_stderr(@job_id, user: @user)
+      FlightJobScriptAPI::JobCLI.view_job_stderr(@job_id, user: @user)
     elsif decoded_file_id
-      FlightJobScriptAPI::SystemCommand.view_job_results(@job_id, decoded_file_id, user: @user)
+      FlightJobScriptAPI::JobCLI.view_job_results(@job_id, decoded_file_id, user: @user)
     else
       false
     end

--- a/api/app/models/script.rb
+++ b/api/app/models/script.rb
@@ -31,7 +31,7 @@ class Script
     prepend FlightJobScriptAPI::ModelCache
 
     def index(**opts)
-      cmd = FlightJobScriptAPI::SystemCommand.list_scripts(**opts).tap do |cmd|
+      cmd = FlightJobScriptAPI::JobCLI.list_scripts(**opts).tap do |cmd|
         next if cmd.exitstatus == 0
         raise FlightJobScriptAPI::CommandError, 'Unexpectedly failed to list scripts'
       end
@@ -47,7 +47,7 @@ class Script
     end
 
     def find!(id, **opts)
-      cmd = FlightJobScriptAPI::SystemCommand.info_script(id, **opts).tap do |cmd|
+      cmd = FlightJobScriptAPI::JobCLI.info_script(id, **opts).tap do |cmd|
         next if cmd.exitstatus == 0
         return nil if cmd.exitstatus == 22
         raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to find script: #{id}"
@@ -81,7 +81,7 @@ class Script
   end
 
   def delete
-    FlightJobScriptAPI::SystemCommand.delete_script(id, user: user).tap do |cmd|
+    FlightJobScriptAPI::JobCLI.delete_script(id, user: user).tap do |cmd|
       next if cmd.exitstatus == 0
       raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to delete script: #{id}"
     end

--- a/api/app/models/script.rb
+++ b/api/app/models/script.rb
@@ -31,7 +31,7 @@ class Script
     prepend FlightJobScriptAPI::ModelCache
 
     def index(**opts)
-      cmd = FlightJobScriptAPI::SystemCommand.flight_list_scripts(**opts).tap do |cmd|
+      cmd = FlightJobScriptAPI::SystemCommand.list_scripts(**opts).tap do |cmd|
         next if cmd.exitstatus == 0
         raise FlightJobScriptAPI::CommandError, 'Unexpectedly failed to list scripts'
       end
@@ -47,7 +47,7 @@ class Script
     end
 
     def find!(id, **opts)
-      cmd = FlightJobScriptAPI::SystemCommand.flight_info_script(id, **opts).tap do |cmd|
+      cmd = FlightJobScriptAPI::SystemCommand.info_script(id, **opts).tap do |cmd|
         next if cmd.exitstatus == 0
         return nil if cmd.exitstatus == 22
         raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to find script: #{id}"
@@ -81,7 +81,7 @@ class Script
   end
 
   def delete
-    FlightJobScriptAPI::SystemCommand.flight_delete_script(id, user: user).tap do |cmd|
+    FlightJobScriptAPI::SystemCommand.delete_script(id, user: user).tap do |cmd|
       next if cmd.exitstatus == 0
       raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to delete script: #{id}"
     end

--- a/api/app/models/script.rb
+++ b/api/app/models/script.rb
@@ -35,7 +35,7 @@ class Script
         next if cmd.exitstatus == 0
         raise FlightJobScriptAPI::CommandError, 'Unexpectedly failed to list scripts'
       end
-      JSON.parse(cmd.stdout).map do |metadata|
+      cmd.stdout.map do |metadata|
         new(user: opts[:user], **metadata)
       end
     end
@@ -53,7 +53,7 @@ class Script
         raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to find script: #{id}"
       end
 
-      new(user: opts[:user], **JSON.parse(cmd.stdout))
+      new(user: opts[:user], **cmd.stdout)
     end
   end
 

--- a/api/app/models/script_content.rb
+++ b/api/app/models/script_content.rb
@@ -49,7 +49,7 @@ class ScriptContent
   end
 
   def save_payload(content)
-    FlightJobScriptAPI::SystemCommand.edit_script(
+    FlightJobScriptAPI::JobCLI.edit_script(
       id, user: script.user, stdin: content
     ).tap do |cmd|
       next if cmd.exitstatus == 0

--- a/api/app/models/script_content.rb
+++ b/api/app/models/script_content.rb
@@ -49,7 +49,7 @@ class ScriptContent
   end
 
   def save_payload(content)
-    FlightJobScriptAPI::SystemCommand.flight_edit_script(
+    FlightJobScriptAPI::SystemCommand.edit_script(
       id, user: script.user, stdin: content
     ).tap do |cmd|
       next if cmd.exitstatus == 0

--- a/api/app/models/script_note.rb
+++ b/api/app/models/script_note.rb
@@ -48,7 +48,7 @@ class ScriptNote
   end
 
   def save_payload(content)
-    FlightJobScriptAPI::SystemCommand.edit_script_notes(
+    FlightJobScriptAPI::JobCLI.edit_script_notes(
       id, user: script.user, stdin: content
     ).tap do |cmd|
       next if cmd.exitstatus == 0

--- a/api/app/models/script_note.rb
+++ b/api/app/models/script_note.rb
@@ -48,7 +48,7 @@ class ScriptNote
   end
 
   def save_payload(content)
-    FlightJobScriptAPI::SystemCommand.flight_edit_script_notes(
+    FlightJobScriptAPI::SystemCommand.edit_script_notes(
       id, user: script.user, stdin: content
     ).tap do |cmd|
       next if cmd.exitstatus == 0

--- a/api/app/models/template.rb
+++ b/api/app/models/template.rb
@@ -31,7 +31,7 @@ class Template
     prepend FlightJobScriptAPI::ModelCache
 
     def index(**opts)
-      cmd = FlightJobScriptAPI::SystemCommand.list_templates(**opts).tap do |cmd|
+      cmd = FlightJobScriptAPI::JobCLI.list_templates(**opts).tap do |cmd|
         next if cmd.exitstatus == 0
         raise FlightJobScriptAPI::CommandError, 'Unexpectedly failed to list templates'
       end
@@ -55,7 +55,7 @@ class Template
       #       being ignored
       return if /\A\d+\Z/.match?(id)
 
-      cmd = FlightJobScriptAPI::SystemCommand.info_template(id, **opts).tap do |cmd|
+      cmd = FlightJobScriptAPI::JobCLI.info_template(id, **opts).tap do |cmd|
         next if cmd.exitstatus == 0
         return nil if cmd.exitstatus == 21
         raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to find template: #{id}"

--- a/api/app/models/template.rb
+++ b/api/app/models/template.rb
@@ -35,7 +35,7 @@ class Template
         next if cmd.exitstatus == 0
         raise FlightJobScriptAPI::CommandError, 'Unexpectedly failed to list templates'
       end
-      JSON.parse(cmd.stdout).map do |metadata|
+      cmd.stdout.map do |metadata|
         new(**metadata)
       end
     end
@@ -61,7 +61,7 @@ class Template
         raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to find template: #{id}"
       end
 
-      new(**JSON.parse(cmd.stdout))
+      new(**cmd.stdout)
     end
   end
 

--- a/api/app/models/template.rb
+++ b/api/app/models/template.rb
@@ -31,7 +31,7 @@ class Template
     prepend FlightJobScriptAPI::ModelCache
 
     def index(**opts)
-      cmd = FlightJobScriptAPI::SystemCommand.flight_list_templates(**opts).tap do |cmd|
+      cmd = FlightJobScriptAPI::SystemCommand.list_templates(**opts).tap do |cmd|
         next if cmd.exitstatus == 0
         raise FlightJobScriptAPI::CommandError, 'Unexpectedly failed to list templates'
       end
@@ -55,7 +55,7 @@ class Template
       #       being ignored
       return if /\A\d+\Z/.match?(id)
 
-      cmd = FlightJobScriptAPI::SystemCommand.flight_info_template(id, **opts).tap do |cmd|
+      cmd = FlightJobScriptAPI::SystemCommand.info_template(id, **opts).tap do |cmd|
         next if cmd.exitstatus == 0
         return nil if cmd.exitstatus == 21
         raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to find template: #{id}"

--- a/api/lib/flight_job_script_api.rb
+++ b/api/lib/flight_job_script_api.rb
@@ -31,6 +31,7 @@ module FlightJobScriptAPI
   autoload(:ModelCache, 'flight_job_script_api/model_cache')
   autoload(:SystemCommand, 'flight_job_script_api/system_command')
   autoload(:CommandError, 'flight_job_script_api/system_command')
+  autoload(:Subprocess, 'flight_job_script_api/subprocess')
 
   class UnexpectedError < StandardError; end
 

--- a/api/lib/flight_job_script_api.rb
+++ b/api/lib/flight_job_script_api.rb
@@ -29,8 +29,8 @@
 module FlightJobScriptAPI
   autoload(:Configuration, 'flight_job_script_api/configuration')
   autoload(:ModelCache, 'flight_job_script_api/model_cache')
-  autoload(:SystemCommand, 'flight_job_script_api/system_command')
-  autoload(:CommandError, 'flight_job_script_api/system_command')
+  autoload(:JobCLI, 'flight_job_script_api/job_cli')
+  autoload(:CommandError, 'flight_job_script_api/job_cli')
   autoload(:Subprocess, 'flight_job_script_api/subprocess')
 
   class UnexpectedError < StandardError; end

--- a/api/lib/flight_job_script_api/job_cli.rb
+++ b/api/lib/flight_job_script_api/job_cli.rb
@@ -151,12 +151,10 @@ module FlightJobScriptAPI
         self.class.mutexes[@user].synchronize do
           FlightJobScriptAPI.logger.debug("Running subprocess (#{@user}): #{stringified_cmd}")
           sp = Subprocess.new(
-            dir: passwd.dir,
             env: @env,
-            gid: passwd.gid,
             logger: FlightJobScriptAPI.logger,
             timeout: FlightJobScriptAPI.config.command_timeout,
-            uid: passwd.uid,
+            username: @user,
           )
           sp.run(@cmd.first == :noop ? nil : @cmd, @stdin, &block)
         end

--- a/api/lib/flight_job_script_api/job_cli.rb
+++ b/api/lib/flight_job_script_api/job_cli.rb
@@ -31,7 +31,7 @@ require 'pathname'
 module FlightJobScriptAPI
   class CommandError < Sinja::ServiceUnavailable; end
 
-  class SystemCommand
+  class JobCLI
     class << self
       # Used to ensure each user is only running a single command at at time
       # NOTE: These objects will be indefinitely cached in memory until the server
@@ -178,7 +178,6 @@ module FlightJobScriptAPI
         STATUS: #{result.exitstatus}
       INFO
       FlightJobScriptAPI.logger.debug <<~DEBUG
-
         STDIN:
         #{@stdin.to_s}
         STDOUT:

--- a/api/lib/flight_job_script_api/subprocess.rb
+++ b/api/lib/flight_job_script_api/subprocess.rb
@@ -1,0 +1,190 @@
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
+#
+# This file is part of Flight Job Script Service.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Job Script Service is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Job Script Service. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Job Script Service, please visit:
+# https://github.com/openflighthpc/flight-job-script-service
+#==============================================================================
+
+module FlightJobScriptAPI
+  class Subprocess
+    class Result < Struct.new(:stdout, :stderr, :exitstatus, :pid); end
+
+    def initialize(dir:, env:, gid:, logger:, timeout:, uid:)
+      @dir = dir
+      @env = env
+      @gid = gid
+      @logger = logger
+      @timeout = timeout
+      @uid = uid
+    end
+
+    def run(cmd, stdin, &block)
+      @stdout = ""
+      @stderr = ""
+      @read_threads = []
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      create_pipes
+      run_fork do
+        run_command(cmd, &block)
+      end
+      start_read_threads
+      write_stdin(stdin)
+      status = wait_for_process
+      wait_for_read_threads(start_time)
+      exit_code = determine_exit_code(status)
+
+      Result.new(@stdout, @stderr, exit_code, @pid)
+    ensure
+      close_pipes
+    end
+
+    private
+
+    def run_fork(&block)
+      @pid = Kernel.fork do
+        @out_read.close
+        @err_read.close
+        @in_write.close
+
+        Process::Sys.setgid(@gid)
+        Process::Sys.setuid(@uid)
+        Process.setsid
+
+        block.call if block
+      end
+      @logger.debug("Forked process #{@pid.inspect}")
+      @out_write.close
+      @err_write.close
+      @in_read.close
+    end
+
+    def run_command(cmd, &block)
+      block.call(@out_write, @err_write) if block
+      if cmd.nil?
+        @logger.debug("Nothing to exec")
+        return 
+      end
+
+      opts = {
+        unsetenv_others: true,
+        close_others: true,
+        chdir: @dir,
+        out: @out_write,
+        err: @err_write,
+        in: @in_read,
+      }
+      @logger.debug("Execing cmd")
+      Kernel.exec(@env, *cmd, **opts)
+    end
+
+    def start_read_threads
+      [ [@out_read, @stdout], [@err_read, @stderr] ].each do |io, buffer|
+        @read_threads << Thread.new do
+          begin
+            loop { buffer << io.readpartial(1024) }
+          rescue IOError
+            # NOOP - Both EOF and IO closed errors need to be caught
+          end
+        end
+      end
+    end
+
+    def write_stdin(stdin)
+      return if stdin.nil?
+      # We assume here that stdin is small enough to not cause an issue.  The
+      # process and the read threads have been started so we should be OK with
+      # that assumption.
+      @in_write.write(stdin)
+    end
+
+    def wait_for_process
+      signal = 'TERM'
+      begin
+        @logger.debug("Waiting for pid: #{@pid}")
+        Timeout.timeout(@timeout) do
+          Process.wait(@pid)
+        end
+      rescue Timeout::Error
+        @logger.error("Sending #{signal} to: #{@pid}")
+        Process.kill(-Signal.list[signal], @pid)
+        signal = 'KILL'
+        retry
+      end
+      $?
+    end
+
+    def determine_exit_code(status)
+      if @read_threads.any?(&:alive?)
+        @logger.warn "Read threads still alive.  Setting exit code to 128."
+        128
+      elsif status.exitstatus
+        status.exitstatus
+      elsif status.signaled?
+        @logger.warn <<~WARN.chomp
+          Inferring exit code from signal #{Signal.signame(status.termsig)} (pid: #{@pid})
+        WARN
+        status.termsig + 128
+      else
+        @logger.error "No exit code provided (pid: #{@pid})!"
+        128
+      end
+    end
+
+    # Wait for the remaining timeout for the read threads to finish.
+    #
+    # As the subprocess has completed, we would usually expect that the pipes
+    # are closed and the next reads will read any remaining data.  There are
+    # some circumstances, involving zombie grandchild processes, where that
+    # might not be the case.
+    #
+    # We want to ensure that waiting on the read threads does not cause
+    # `Subprocess#run` to hang for longer than `@timeout`.
+    def wait_for_read_threads(start_time)
+      loop do
+        break if @read_threads.none?(&:alive?)
+
+        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        remaining = @timeout + start_time - now
+        break unless remaining > 0
+
+        @read_threads.select(&:alive?).first.join(remaining)
+      end
+    end
+
+    def create_pipes
+      @out_read, @out_write = IO.pipe
+      @err_read, @err_write = IO.pipe
+      @in_read,  @in_write  = IO.pipe
+    end
+
+    def close_pipes
+      @out_read.close  if @out_read  && !@out_read.closed?
+      @out_write.close if @out_write && !@out_write.closed?
+      @err_read.close  if @err_read  && !@err_read.closed?
+      @err_write.close if @err_write && !@err_write.closed?
+      @in_read.close   if @in_read   && !@in_read.closed?
+      @in_write.close  if @in_write  && !@in_write.closed?
+    end
+  end
+end

--- a/api/lib/flight_job_script_api/system_command.rb
+++ b/api/lib/flight_job_script_api/system_command.rb
@@ -42,19 +42,19 @@ module FlightJobScriptAPI
     end
 
     def self.flight_list_templates(**opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'list-templates', '--json', **opts).tap(&:run)
+      new(*FlightJobScriptAPI.config.flight_job, 'list-templates', '--json', **opts).run
     end
 
     def self.flight_info_template(id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'info-template', id, '--json', **opts).tap(&:run)
+      new(*FlightJobScriptAPI.config.flight_job, 'info-template', id, '--json', **opts).run
     end
 
     def self.flight_list_scripts(**opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'list-scripts', '--json', **opts).tap(&:run)
+      new(*FlightJobScriptAPI.config.flight_job, 'list-scripts', '--json', **opts).run
     end
 
     def self.flight_info_script(id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'info-script', id, '--json', **opts).tap(&:run)
+      new(*FlightJobScriptAPI.config.flight_job, 'info-script', id, '--json', **opts).run
     end
 
     def self.flight_create_script(template_id, name = nil, answers: nil, notes: nil, **opts)
@@ -66,11 +66,10 @@ module FlightJobScriptAPI
       args = name ? [template_id, name] : [template_id]
       args.push('--answers', "@#{answers_path}") if answers
       args.push('--notes', "@#{notes_path}") if notes
-      new(*FlightJobScriptAPI.config.flight_job, 'create-script', *args, '--json', **opts).tap do |sys|
-        sys.run do
-          File.write answers_path, answers if answers
-          File.write notes_path, notes if notes
-        end
+      sys = new(*FlightJobScriptAPI.config.flight_job, 'create-script', *args, '--json', **opts)
+      sys.run do
+        File.write answers_path, answers if answers
+        File.write notes_path, notes if notes
       end
     ensure
       FileUtils.rm_f answers_path
@@ -78,246 +77,111 @@ module FlightJobScriptAPI
     end
 
     def self.flight_edit_script_notes(script_id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'edit-script-notes', script_id, '--json', '--notes', '@-', **opts).tap(&:run)
+      new(*FlightJobScriptAPI.config.flight_job, 'edit-script-notes', script_id, '--json', '--notes', '@-', **opts).run
     end
 
     def self.flight_edit_script(script_id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'edit-script', script_id, '--json', '--force', '--content', '@-', **opts).tap(&:run)
+      new(*FlightJobScriptAPI.config.flight_job, 'edit-script', script_id, '--json', '--force', '--content', '@-', **opts).run
     end
 
     def self.flight_delete_script(id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'delete-script', id, '--json',**opts).tap(&:run)
+      new(*FlightJobScriptAPI.config.flight_job, 'delete-script', id, '--json',**opts).run
     end
 
     def self.flight_list_jobs(**opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'list-jobs', '--json', **opts).tap(&:run)
+      new(*FlightJobScriptAPI.config.flight_job, 'list-jobs', '--json', **opts).run
     end
 
     def self.flight_info_job(id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'info-job', id, '--json', **opts).tap(&:run)
+      new(*FlightJobScriptAPI.config.flight_job, 'info-job', id, '--json', **opts).run
     end
 
     def self.flight_submit_job(script_id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'submit-job', script_id, '--json', **opts).tap(&:run)
+      new(*FlightJobScriptAPI.config.flight_job, 'submit-job', script_id, '--json', **opts).run
     end
 
     def self.flight_view_job_stdout(job_id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'view-job-stdout', job_id, **opts).tap(&:run)
+      new(*FlightJobScriptAPI.config.flight_job, 'view-job-stdout', job_id, **opts).run
     end
 
     def self.flight_view_job_stderr(job_id, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'view-job-stderr', job_id, **opts).tap(&:run)
+      new(*FlightJobScriptAPI.config.flight_job, 'view-job-stderr', job_id, **opts).run
     end
 
     def self.flight_view_job_results(job_id, filename, **opts)
-      new(*FlightJobScriptAPI.config.flight_job, 'view-job-results', job_id, filename, **opts).tap(&:run)
+      new(*FlightJobScriptAPI.config.flight_job, 'view-job-results', job_id, filename, **opts).run
     end
 
     def self.recursive_glob_dir(dir, **opts)
-      new(:noop, 'recursively glob directory', **opts).tap do |sys|
-        sys.run do
-          exit 20 unless Dir.exists?(dir)
-          json = Dir.glob(File.join(dir, '**/*'))
-                    .map { |p| Pathname.new(p) }
-                    .reject(&:directory?)
-                    .reject(&:symlink?)
-                    .select(&:readable?) # XXX: Non-readable files would be an odd occurrence
-                    .map { |p| { file: p.to_s, size: p.size } }
-          puts JSON.generate(json)
-        end
+      sys = new(:noop, 'recursively glob directory', **opts)
+      sys.run do |stdout, stderr|
+        exit 20 unless Dir.exists?(dir)
+        json = Dir.glob(File.join(dir, '**/*'))
+          .map { |p| Pathname.new(p) }
+          .reject(&:directory?)
+          .reject(&:symlink?)
+          .select(&:readable?) # XXX: Non-readable files would be an odd occurrence
+          .map { |p| { file: p.to_s, size: p.size } }
+        stdout.puts(JSON.generate(json))
       end
     end
 
-    attr_reader :cmd, :user, :mutex, :stdin, :env, :stdout, :stderr
-    attr_accessor :exitstatus, :pid
-
     def initialize(*cmd, user:, stdin: nil, env: {})
-      @stdout = ""
-      @stderr = ""
       @cmd = cmd
       @user = user
       @stdin = stdin
-      @env ||= {
+      @env = {
         'PATH' => FlightJobScriptAPI.app.config.command_path,
         'HOME' => passwd.dir,
-        'USER' => user,
-        'LOGNAME' => user
+        'USER' => @user,
+        'LOGNAME' => @user
       }.merge(env)
     end
 
     def run(&block)
-      with_fork do
-        # Log the command has been forked
-        FlightJobScriptAPI.logger.debug("Forked Command (#{user}): #{stringified_cmd}")
-
-        # Close the parent pipes
-        @out_read.close
-        @err_read.close
-        @in_write.close
-
-        # Become the user
-        Process::Sys.setgid(passwd.gid)
-        Process::Sys.setuid(passwd.uid)
-        Process.setsid
-
-        # Allow the command to be modified after becoming the requested user
-        # This is useful when trying to create a file with the correct file permissions
-        $stdout = @out_write
-        $stderr = @err_write
-        block.call if block
-
-        if cmd.first == :noop
-           FlightJobScriptAPI.logger.debug("Nothing to exec")
-        else
-          # Execute the command
-          opts = {
-            unsetenv_others: true, close_others: true, chdir: passwd.dir,
-            out: @out_write, err: @err_write, in: @in_read
-          }
-          # NOTE: Keep the log before the exec for timing purposes
-          FlightJobScriptAPI.logger.debug("Executing (#{user}): #{stringified_cmd}")
-          Kernel.exec(env, *cmd, **opts)
+      result =
+        self.class.mutexes[@user].synchronize do
+          FlightJobScriptAPI.logger.debug("Running subprocess (#{@user}): #{stringified_cmd}")
+          sp = Subprocess.new(
+            dir: passwd.dir,
+            env: @env,
+            gid: passwd.gid,
+            logger: FlightJobScriptAPI.logger,
+            timeout: FlightJobScriptAPI.config.command_timeout,
+            uid: passwd.uid,
+          )
+          sp.run(@cmd.first == :noop ? nil : @cmd, @stdin, &block)
         end
-      end
+      log_command(result)
+      result
     end
 
     private
 
     def passwd
-      @passwd ||= Etc.getpwnam(user)
+      @passwd ||= Etc.getpwnam(@user)
     end
 
-    def with_fork(&block)
-      self.class.mutexes[user].synchronize do
-        begin
-          # Flag the start time
-          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
-          # Create the pipes
-          @out_read,  @out_write = IO.pipe
-          @err_read,  @err_write = IO.pipe
-          @in_read,   @in_write  = IO.pipe
-
-          # Start the thread
-          @threads = [[@out_read, self.stdout], [@err_read, self.stderr]].map do |io, buffer|
-            Thread.new do
-              begin
-                loop { buffer << io.readpartial(1024) }
-              rescue IOError
-                # NOOP - Both EOF and IO closed errors need to be caught
-              end
-            end
-          end
-
-          # Write the standard input if required
-          # NOTE: This could *technically* block if stdin exceeds ~60KiB (system dependent)
-          #       The large 'notes'/'answer' inputs are already "passed by file"
-          #       Consider refactoring if it causes an issue
-          in_write.write(stdin) if stdin
-
-          # Fork the child process
-          FlightJobScriptAPI.logger.debug("Forking Process")
-          self.pid = Kernel.fork(&block)
-
-          # Close the child pipes
-          @out_write.close
-          @err_write.close
-          @in_read.close
-
-          # Wait for the child to end
-          wait_for_status
-
-          # Use the remaining time out to allow the threads to end naturally
-          @threads.each do |thread|
-            next unless thread.alive?
-            now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-            remaining = FlightJobScriptAPI.config.command_timeout + start - now
-            break unless remaining > 0
-            thread.join(remaining)
-          end
-        ensure
-          # Confirm the threads have naturally finished
-          if @threads && @threads.any?(&:alive?)
-            FlightJobScriptAPI.logger.error <<~ERROR.chomp
-              Failed to read all of stdout/stderr for pid: #{pid}
-            ERROR
-            self.exitstatus = 128 if self.exitstatus < 128 || self.exitstatus > 159
-          end
-
-          # Close the pipes and force the threads to finish
-          @out_read.close  if @out_read   && !@out_read.closed?
-          @out_write.close if @out_write  && !@out_write.closed?
-          @err_read.close  if @err_read   && !@err_read.closed?
-          @err_write.close if @err_write  && !@err_write.closed?
-          @in_read.close   if @in_read    && !@in_read.closed?
-          @in_write.close  if @in_write   && !@in_write.closed?
-
-          # Join the threads
-          (@threads || []).each do |thread|
-            begin
-              thread.join # NOTE: Dead threads can be joined multiple times without error
-            rescue
-              FlightJobScriptAPI.logger.error <<~ERROR.chomp
-                An error occur when joining stdout/stdderr thread: #{$!}
-              ERROR
-            end
-          end
-
-          log_command
-        end
-      end
-    end
-
-    def wait_for_status
-      # Wait for the command to finish within the timelimit
-      signal = 'TERM'
-      begin
-        FlightJobScriptAPI.logger.debug("Waiting for pid: #{pid}")
-        Timeout.timeout(FlightJobScriptAPI.app.config.command_timeout) do
-          Process.wait(pid)
-        end
-      rescue Timeout::Error
-        FlightJobScriptAPI.logger.error("Sending #{signal} to: #{pid}")
-        Process.kill(-Signal.list[signal], pid)
-        signal = 'KILL'
-        retry
-      end
-
-      status =  $?
-      self.exitstatus = if status.exitstatus
-        status.exitstatus
-      elsif status.signaled?
-        FlightJobScriptAPI.logger.warn <<~WARN.chomp
-          Inferring exit code from signal #{Signal.signame(status.termsig)} (pid: #{pid})
-        WARN
-        status.termsig + 128
-      else
-        FlightJobScriptAPI.logger.error "No exit code provided (pid: #{pid})!"
-        128
-      end
-    end
-
-    def log_command
+    def log_command(result)
       FlightJobScriptAPI.logger.info <<~INFO.chomp
-
         COMMAND: #{stringified_cmd}
-        USER: #{user}
-        PID: #{pid}
-        STATUS: #{exitstatus}
+        USER: #{@user}
+        PID: #{result.pid}
+        STATUS: #{result.exitstatus}
       INFO
       FlightJobScriptAPI.logger.debug <<~DEBUG
 
         STDIN:
-        #{stdin.to_s}
+        #{@stdin.to_s}
         STDOUT:
-        #{stdout}
+        #{result.stdout}
         STDERR:
-        #{stderr}
+        #{result.stderr}
       DEBUG
     end
 
     def stringified_cmd
-      @stringified_cmd ||= (cmd.first == :noop ? cmd[1..-1] : cmd)
+      @stringified_cmd ||= (@cmd.first == :noop ? @cmd[1..-1] : @cmd)
         .map { |s| s.empty? ? '""' : s }.join(' ')
     end
   end


### PR DESCRIPTION
This PR fixes an issue where editing script content and notes was broken.

The issue was down to `SystemCommand` somehow losing the exit status for the process it created.  In an attempt to understand exactly how, I've significantly refactored `SystemCommand`.

* A generic `Subprocess` class has been extracted from `SystemCommand`.  It has no Flight Job Script API specific code to it.
* `SystemCommand` has been renamed to `JobCLI` and the `flight_` prefix removed from its class methods.  We now have call sites such as `JobCLI.list_templates` instead of `SystemCommand.flight_list_templates`.
* We don't wait for upto twice the timeout for a command to terminate.
* The mechansim for dealing the zombie grandchild processes has been simplified.  See commit message in 4c5e86c1e7e12e3adfaf56b44a01c0afa9eb8b58 for details.
