### PR TITLE
Implement a cancel job route and button

### DIFF
--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -18,6 +18,8 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (5.2.4.4)
+      activesupport (= 5.2.4.4)
     activesupport (5.2.4.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -117,6 +119,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activemodel
   activesupport
   concurrent-ruby
   dotenv

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -18,8 +18,6 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.4.4)
-      activesupport (= 5.2.4.4)
     activesupport (5.2.4.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -119,7 +117,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activemodel
   activesupport
   concurrent-ruby
   dotenv

--- a/api/app.rb
+++ b/api/app.rb
@@ -209,8 +209,6 @@ class App < Sinatra::Base
       def validate!
         if @action == :create
           resource.submit
-        else
-          raise Sinja::ForbiddenError, 'Jobs can not be modfied!'
         end
       end
     end
@@ -227,6 +225,13 @@ class App < Sinatra::Base
       # However the actual ID won't be assigned until later, so a temporary ID
       # is used instead.
       ['temporary', Job.new(user: current_user)]
+    end
+
+    update do |attr|
+      unless attr == { state: 'CANCELLED' }
+        raise Sinja::BadRequestError, "Illegally trying to update a job"
+      end
+      resource.tap(&:cancel)
     end
 
     has_one :script do

--- a/api/app/models/job.rb
+++ b/api/app/models/job.rb
@@ -112,7 +112,7 @@ class Job
     cmd = FlightJobScriptAPI::JobCLI.cancel_job(id, user: user).tap do |cmd|
       next if cmd.exitstatus == 0
       if cmd.exitstatus == 22
-        raise MissingScript, "Failed to locate script : #{script_id}"
+        raise MissingScript, "Unexpectedly failed to find job : #{id}"
       else
         raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to cancel job"
       end

--- a/api/app/models/job.rb
+++ b/api/app/models/job.rb
@@ -108,6 +108,18 @@ class Job
     @metadata = cmd.stdout
   end
 
+  def cancel
+    cmd = FlightJobScriptAPI::JobCLI.cancel_job(id, user: user).tap do |cmd|
+      next if cmd.exitstatus == 0
+      if cmd.exitstatus == 22
+        raise MissingScript, "Failed to locate script : #{script_id}"
+      else
+        raise FlightJobScriptAPI::CommandError, "Unexpectedly failed to cancel job"
+      end
+    end
+    @metadata = cmd.stdout
+  end
+
   def index_result_files
     JobFile.index_job_results(self.id, user: user)
   end

--- a/api/docs/routes.md
+++ b/api/docs/routes.md
@@ -612,6 +612,42 @@ Content-Type: application/vnd.api+json
 }
 ```
 
+## PATCH (cancel) - /jobs/:id
+
+Attempt to cancel the job given by `id`. This method SHOULD set the `state` to `CANCELLED` on `200 OK` response, however it MAY respond `200 OK` with:
+
+* Another terminal `state` if the job has already finished, or
+* Any other `state` if the cancellation was successfully started but not completed.
+
+\*NOTE: The alternative `200 OK` response are volatile and may change in a future release.
+
+```
+GET /v0/scripts/:id
+Authorization: basic <base64 username:password>
+Accept: application/vnd.api+json
+
+{
+  "data": {
+    "type": "jobs",
+    "id": <id>,
+    "attributes": {
+      "state": "CANCELLED"
+    }
+  }
+}
+
+HTTP/2 200 OK
+Content-Type: application/vnd.api+json
+{
+  "data": JobResource,
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "included": [
+  ]
+```
+
+
 ## GET - /jobs/:id/desktop
 
 Return the related `desktop` resource for a `job`.

--- a/api/lib/flight_job_script_api/job_cli.rb
+++ b/api/lib/flight_job_script_api/job_cli.rb
@@ -102,6 +102,10 @@ module FlightJobScriptAPI
         new(*flight_job, 'submit-job', script_id, '--json', **opts).run
       end
 
+      def cancel_job(id, **opts)
+        new(*flight_job, 'cancel-job', id, '--json', **opts).run
+      end
+
       private
 
       def flight_job

--- a/client/src/CancelJobButton.js
+++ b/client/src/CancelJobButton.js
@@ -1,0 +1,74 @@
+import { ConfirmedActionButton, utils, } from 'flight-webapp-components';
+
+import { useCancelJob } from './api';
+import { useToast } from './ToastContext';
+
+function CancelJobButton({
+  className,
+  onCancel=()=>{},
+  onCancelled=()=>{},
+  job,
+}) {
+  const { loading, patch, response } = useCancelJob(job.id)
+  const { addToast } = useToast();
+  const cancelJob = async () => {
+    onCancel();
+    try {
+      const responseBody = await patch();
+      if (response.ok) {
+        onCancelled(response);
+      } else {
+        addToast(cancelFailedToast({
+          job: job,
+          errorCode: utils.errorCode(responseBody),
+        }));
+      }
+    } catch (e) {
+      console.log(e);
+      addToast(cancelFailedToast({
+        job: job,
+        errorCode: undefined,
+      }));
+    }
+  };
+
+  return (
+    <ConfirmedActionButton
+      act={cancelJob}
+      acting={loading}
+      actingButtonText="Cancelling..."
+      buttonText="Cancel"
+      className={className}
+      confirmationHeaderText="Confirm job cancellation"
+      confirmationText={
+        <>
+          <p>
+            Are you sure you want to cancel this job?
+          </p>
+          <p>
+            Cancelling the job may prevent it from fully processing its data.
+          </p>
+        </>
+      }
+      icon="fa-ban"
+      id={`cancel-job-${job.id}`}
+    />
+  );
+}
+
+function cancelFailedToast({ job, errorCode }) {
+  return {
+    body: (
+      <div>
+        Unfortunately there has been a problem cancelling your job.
+        Please try again and, if problems persist, help us to
+        more quickly rectify the problem by contacting us and letting us
+        know.
+      </div>
+    ),
+    icon: 'danger',
+    header: 'Failed to cancel job',
+  };
+}
+
+export default CancelJobButton;

--- a/client/src/JobActions.js
+++ b/client/src/JobActions.js
@@ -1,0 +1,18 @@
+import classNames from 'classnames';
+import { ButtonToolbar } from 'reactstrap';
+
+import CancelJobButton from './CancelJobButton';
+
+function JobActions({ className, job, onCancel, onCancelled }) {
+  return (
+    <ButtonToolbar className={classNames(className)} >
+      <CancelJobButton
+        job={job}
+        onCancel={onCancel}
+        onCancelled={onCancelled}
+      />
+    </ButtonToolbar>
+  );
+}
+
+export default JobActions;

--- a/client/src/JobMetadataCard.js
+++ b/client/src/JobMetadataCard.js
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { useState } from 'react';
 import { Badge } from 'reactstrap';
 import { Link } from 'react-router-dom';
 
@@ -18,7 +19,9 @@ function endTimeNameFromState(state) {
 }
 
 function JobMetadataCard({ className, job }) {
-  const jobState = job.attributes.state;
+  const [jobAttributes, setJobAttributes] = useState(job.attributes);
+
+  const jobState = jobAttributes.state
   const colour = stateColourMap[jobState];
 
   return (
@@ -45,7 +48,7 @@ function JobMetadataCard({ className, job }) {
           />
           <MetadataEntry
             name="Scheduler ID"
-            value={job.attributes.schedulerId}
+            value={jobAttributes.schedulerId}
             format={(value) => (
               value == null ? <span>&mdash;</span> : <code>{value}</code>
             )}
@@ -58,7 +61,7 @@ function JobMetadataCard({ className, job }) {
           <MetadataEntry
             hideWhenNull
             name="Reason"
-            value={job.attributes.reason}
+            value={jobAttributes.reason}
           />
           <MetadataEntry
             name="Script"
@@ -76,31 +79,31 @@ function JobMetadataCard({ className, job }) {
           />
           <MetadataEntry
             name="Submitted"
-            value={job.attributes.createdAt}
+            value={jobAttributes.createdAt}
             format={(value) => <TimeAgo date={value} />}
           />
           <MetadataEntry
             format={(value) => <TimeAgo date={value} />}
             hideWhenNull
             name="Started"
-            value={job.attributes.startTime}
+            value={jobAttributes.startTime}
           />
           <EstimatedTime
-            job={job}
-            estimated={job.attributes.estimatedStartTime}
-            known={job.attributes.startTime}
+            jobAttributes={jobAttributes}
+            estimated={jobAttributes.estimatedStartTime}
+            known={jobAttributes.startTime}
             name="Starts"
           />
           <MetadataEntry
             format={(value) => <TimeAgo date={value} />}
             hideWhenNull
             name={endTimeNameFromState(jobState)}
-            value={job.attributes.endTime}
+            value={jobAttributes.endTime}
           />
           <EstimatedTime
-            estimated={job.attributes.estimatedEndTime}
-            job={job}
-            known={job.attributes.endTime}
+            estimated={jobAttributes.estimatedEndTime}
+            jobAttributes={jobAttributes}
+            known={jobAttributes.endTime}
             name="Completes"
           />
         </dl>
@@ -109,9 +112,9 @@ function JobMetadataCard({ className, job }) {
   );
 }
 
-function EstimatedTime({estimated, job, known, name}) {
+function EstimatedTime({estimated, jobAttributes, known, name}) {
   let unknown_estimate = "currently unknown";
-  if (job.attributes.state === 'FAILED' || job.attributes.state === 'UNKNOWN') {
+  if (jobAttributes.state === 'FAILED' || jobAttributes.state === 'UNKNOWN') {
     unknown_estimate = 'N/A';
   }
 

--- a/client/src/JobMetadataCard.js
+++ b/client/src/JobMetadataCard.js
@@ -9,6 +9,7 @@ import { stateColourMap } from './utils';
 import JobStateBadges from './JobStateBadges';
 
 import { useCancelJob } from './api';
+import { useToast } from './ToastContext';
 
 function endTimeNameFromState(state) {
   if (state === 'CANCELLED') {
@@ -144,6 +145,7 @@ function EstimatedTime({estimated, jobAttributes, known, name}) {
 
 function CancelButton({id, jobAttributes, setJobAttributes}) {
   const { loading, patch, response } = useCancelJob(id)
+  const { addToast } = useToast();
 
   if (["PENDING", "RUNNING"].includes(jobAttributes.state)) {
     const cancel = async() => {
@@ -152,6 +154,18 @@ function CancelButton({id, jobAttributes, setJobAttributes}) {
         setJobAttributes(response.data.data.attributes);
       } else {
         console.log("Failed to cancel job");
+        addToast({
+          body: (
+            <div>
+              Unfortunately there has been a problem cancel your job.
+              Please try again and, if problems persist, help us to
+              more quickly rectify the problem by contacting us and letting us
+              know.
+            </div>
+          ),
+          icon: 'danger',
+          header: 'Failed to cancel job',
+        });
       }
     }
 

--- a/client/src/JobMetadataCard.js
+++ b/client/src/JobMetadataCard.js
@@ -146,12 +146,27 @@ function EstimatedTime({estimated, jobAttributes, known, name}) {
 function CancelButton({id, jobAttributes, setJobAttributes}) {
   const { loading, patch, response } = useCancelJob(id)
   const { addToast } = useToast();
+  const isActive = function() {
+    return(["PENDING", "RUNNING"].includes(jobAttributes.state));
+  }
 
-  if (["PENDING", "RUNNING"].includes(jobAttributes.state)) {
+  if (isActive()) {
     const cancel = async() => {
       await patch();
       if (response.ok) {
         setJobAttributes(response.data.data.attributes);
+        if (isActive()) {
+          addToast({
+            body: (
+              <div>
+                Your request to cancel the job has been received
+                and will be completed shortly. Please check again latter.
+              </div>
+            ),
+            icon: 'success',
+            header: 'Cancellation Started',
+          });
+        }
       } else {
         console.log("Failed to cancel job");
         addToast({

--- a/client/src/JobMetadataCard.js
+++ b/client/src/JobMetadataCard.js
@@ -146,46 +146,42 @@ function EstimatedTime({estimated, jobAttributes, known, name}) {
 function CancelButton({id, jobAttributes, setJobAttributes}) {
   const { loading, patch, response } = useCancelJob(id)
   const { addToast } = useToast();
-  const isActive = function() {
-    return(["PENDING", "RUNNING"].includes(jobAttributes.state));
-  }
+  const icon = loading ? 'fa-spin fa-spinner' : 'fa-ban'
 
-  if (isActive()) {
-    const cancel = async() => {
-      await patch();
-      if (response.ok) {
-        setJobAttributes(response.data.data.attributes);
-        if (isActive()) {
-          addToast({
-            body: (
-              <div>
-                Your request to cancel the job has been received
-                and will be completed shortly. Please check again latter.
-              </div>
-            ),
-            icon: 'success',
-            header: 'Cancellation Started',
-          });
-        }
-      } else {
-        console.log("Failed to cancel job");
+  const cancel = async() => {
+    await patch();
+    if (response.ok) {
+      setJobAttributes(response.data.data.attributes);
+      if (["PENDING", "RUNNING"].includes(response.data.data.attributes.state)) {
         addToast({
           body: (
             <div>
-              Unfortunately there has been a problem cancel your job.
-              Please try again and, if problems persist, help us to
-              more quickly rectify the problem by contacting us and letting us
-              know.
+              Your request to cancel the job has been received
+              and will be completed shortly. Please check again latter.
             </div>
           ),
-          icon: 'danger',
-          header: 'Failed to cancel job',
+          icon: 'success',
+          header: 'Cancellation Started',
         });
       }
+    } else {
+      console.log("Failed to cancel job");
+      addToast({
+        body: (
+          <div>
+            Unfortunately there has been a problem cancel your job.
+            Please try again and, if problems persist, help us to
+            more quickly rectify the problem by contacting us and letting us
+            know.
+          </div>
+        ),
+        icon: 'danger',
+        header: 'Failed to cancel job',
+      });
     }
+  }
 
-    const icon = loading ? 'fa-spin fa-spinner' : 'fa-ban'
-
+  if (["PENDING", "RUNNING"].includes(jobAttributes.state)) {
     return (
       <Button
         color="danger"

--- a/client/src/JobMetadataCard.js
+++ b/client/src/JobMetadataCard.js
@@ -1,12 +1,14 @@
 import classNames from 'classnames';
 import { useState } from 'react';
-import { Badge } from 'reactstrap';
+import { Button, Badge } from 'reactstrap';
 import { Link } from 'react-router-dom';
 
 import MetadataEntry from './MetadataEntry';
 import TimeAgo from './TimeAgo';
 import { stateColourMap } from './utils';
 import JobStateBadges from './JobStateBadges';
+
+import { useCancelJob } from './api';
 
 function endTimeNameFromState(state) {
   if (state === 'CANCELLED') {
@@ -36,6 +38,11 @@ function JobMetadataCard({ className, job }) {
           Job <code>{job.id}</code>
         </span>
         <span>
+          <CancelButton
+            id={job.id}
+            jobAttributes={jobAttributes}
+            setJobAttributes={setJobAttributes}
+          />
           <Badge color={colour}>{jobState}</Badge>
         </span>
       </h4>
@@ -133,6 +140,36 @@ function EstimatedTime({estimated, jobAttributes, known, name}) {
       value={estimated == null ? unknown_estimate : estimated}
     />
   );
+}
+
+function CancelButton({id, jobAttributes, setJobAttributes}) {
+  const { loading, patch, response } = useCancelJob(id)
+
+  if (["PENDING", "RUNNING"].includes(jobAttributes.state)) {
+    const cancel = async() => {
+      await patch();
+      if (response.ok) {
+        setJobAttributes(response.data.data.attributes);
+      } else {
+        console.log("Failed to cancel job");
+      }
+    }
+
+    return (
+      <Button
+        color="danger"
+        onClick={cancel}
+        className={classNames({ 'disabled': loading })}
+        disabled={loading}
+        size="sm"
+      >
+        <i className={`fa fa-ban mr-1`}></i>
+        <span>Cancel</span>
+      </Button>
+    );
+  } else {
+    return <></>;
+  }
 }
 
 export default JobMetadataCard;

--- a/client/src/JobMetadataCard.js
+++ b/client/src/JobMetadataCard.js
@@ -38,12 +38,12 @@ function JobMetadataCard({ className, job }) {
           Job <code>{job.id}</code>
         </span>
         <span>
+          <Badge color={colour}>{jobState}</Badge>
           <CancelButton
             id={job.id}
             jobAttributes={jobAttributes}
             setJobAttributes={setJobAttributes}
           />
-          <Badge color={colour}>{jobState}</Badge>
         </span>
       </h4>
       <div className="card-body">
@@ -155,15 +155,17 @@ function CancelButton({id, jobAttributes, setJobAttributes}) {
       }
     }
 
+    const icon = loading ? 'fa-spin fa-spinner' : 'fa-ban'
+
     return (
       <Button
         color="danger"
         onClick={cancel}
-        className={classNames({ 'disabled': loading })}
+        className={classNames('ml-2', { 'disabled': loading })}
         disabled={loading}
         size="sm"
       >
-        <i className={`fa fa-ban mr-1`}></i>
+        <i className={`fa ${icon} mr-1`}></i>
         <span>Cancel</span>
       </Button>
     );

--- a/client/src/JobPage.js
+++ b/client/src/JobPage.js
@@ -1,7 +1,6 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import { Col, Row } from 'reactstrap';
 import { useParams } from 'react-router-dom';
-import { useRef } from 'react';
 
 import {
   DefaultErrorMessage,
@@ -17,11 +16,11 @@ import JobSessionCard from './JobSessionCard';
 import SubmissionFailureOutputCard from './SubmissionFailureOutputCard';
 import { useFetchJob } from './api';
 import { useInterval } from './utils';
+import { useToast } from './ToastContext';
 
 function JobPage() {
   const { id } = useParams();
-  const ref = useRef(id);
-  const { data, error, loading, get } = useFetchJob(ref.current);
+  const { data, error, loading, get } = useFetchJob(id);
   useInterval(get, 1 * 60 * 1000);
 
   if (error) {
@@ -35,7 +34,7 @@ function JobPage() {
     return (
       <React.Fragment>
         { loading && <Loading /> }
-        { job != null && <Layout job={job} loading={loading} /> }
+        { job != null && <LayoutContainer job={job} loading={loading} /> }
       </React.Fragment>
     );
   }
@@ -51,17 +50,60 @@ function Loading() {
   );
 }
 
-function Layout({ job, loading }) {
-  if (job == null && !loading) {
+function LayoutContainer({ job, loading }) {
+  const { addToast } = useToast();
+  const [ , forceRender ] = useState(0);
+  const jobRef = useRef(job);
+
+  if (jobRef.current == null && !loading) {
     return <DefaultErrorMessage />;
   }
+
+  const setJob = (job) => {
+    jobRef.current = job;
+    forceRender();
+  }
+  const onCancelled = (response) => {
+    setJob(response.data.data);
+    if (["PENDING", "RUNNING"].includes(jobRef.current.attributes.state)) {
+      addToast({
+        body: (
+          <div>
+            Your request to cancel the job has been received
+            and will be completed shortly. Please check again later.
+          </div>
+        ),
+        icon: 'success',
+        header: 'Cancellation started',
+      });
+    }
+  };
+
+  // Update the job reference when we periodically reload the job.
+  if (job !== jobRef.current) {
+    setJob(job);
+  }
+
+  return (
+    <Layout
+      job={jobRef.current}
+      onCancelled={onCancelled}
+    />
+  );
+}
+
+function Layout({ job, onCancelled }) {
   const submissionFailed = job.attributes.submitStatus !== 0;
 
   return (
     <>
     <Row>
       <Col md={12} lg={5}>
-        <JobMetadataCard className="mb-3" job={job} />
+        <JobMetadataCard
+          className="mb-3"
+          job={job}
+          onCancelled={onCancelled}
+        />
         <JobSessionCard job={job} />
       </Col>
       <Col md={12} lg={7}>

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -287,7 +287,7 @@ export function useFetchJob(id) {
 
 export function useCancelJob(id) {
   const request = useFetch(
-    `/jobs/${id}`,
+    `/jobs/${id}?include=script`,
     {
       method: 'patch',
       headers: {
@@ -301,6 +301,14 @@ export function useCancelJob(id) {
           "attributes": {
             "state": "CANCELLED"
           }
+        }
+      },
+      interceptors: {
+        response: async ({ response }) => {
+          if (response.ok) {
+            denormalizeResponse(response);
+          }
+          return response;
         }
       },
       cachePolicy: 'no-cache',

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -285,6 +285,30 @@ export function useFetchJob(id) {
     [ currentUser.authToken ]);
 }
 
+export function useCancelJob(id) {
+  const request = useFetch(
+    `/jobs/${id}`,
+    {
+      method: 'patch',
+      headers: {
+        Accept: 'application/vnd.api+json',
+        'Content-Type': 'application/vnd.api+json',
+      },
+      body: {
+        "data": {
+          "type": "jobs",
+          "id": id,
+          "attributes": {
+            "state": "CANCELLED"
+          }
+        }
+      },
+      cachePolicy: 'no-cache',
+    },
+  );
+  return request;
+}
+
 export function useFetchOutputFiles(id) {
   const { currentUser } = useContext(CurrentUserContext);
   return useFetch(


### PR DESCRIPTION
This PR repurposed the `PATCH` route to cancel  a `job`. The `job` resource are persisted after being  cancelled, which makes `PATCH` more appropriate than `DELETE`. The `cancel` requests are identified by attempting to set the `state` to `CANCELLED`.

---

This does not necessarily transition the `state` to `CANCELLED`, instead it is more of a _recommendation_. `flight-job` could ultimately return any state:

* `CANCELLED`: What you would expect,
* "terminal": The job already finished, or
* "other": The job successfully started to be cancelled.

Whilst this behaviour isn't ideal, it does keep the API design simple.

---

A `cancel` button has been added to the webapp