### PR TITLE
Fix race condition when joining on alive thread

### DIFF
--- a/api/lib/flight_job_script_api/subprocess.rb
+++ b/api/lib/flight_job_script_api/subprocess.rb
@@ -178,7 +178,9 @@ module FlightJobScriptAPI
         remaining = @timeout + start_time - now
         break unless remaining > 0
 
-        @read_threads.select(&:alive?).first.join(remaining)
+        living_thread = @read_threads.select(&:alive?).first
+        # Guard against potential race condition.
+        living_thread.join(remaining) unless living_thread.nil?
       end
 
       @read_threads.select(&:alive?).map(&:kill)


### PR DESCRIPTION
All live threads could end between the initial check for any living threads and the call to join on the first.