### PR TITLE
Index routes preload included resources

### DIFF
--- a/api/app.rb
+++ b/api/app.rb
@@ -74,6 +74,10 @@ class App < Sinatra::Base
       end
     end
 
+    def include?(resource)
+      include_string.split(',').include?(resource)
+    end
+
     def include_string
       case params.fetch('include', nil)
       when String
@@ -154,7 +158,8 @@ class App < Sinatra::Base
     end
 
     index do
-      Script.index(user: current_user, include: include_string)
+      Template.index(user: current_user) if include?('template')
+      Script.index(user: current_user)
     end
 
     show
@@ -218,7 +223,8 @@ class App < Sinatra::Base
     end
 
     index do
-      Job.index(user: current_user, include: include_string)
+      Script.index(user: current_user) if include?('script')
+      Job.index(user: current_user)
     end
 
     show


### PR DESCRIPTION
The JSON format used between job CLI and API does not yet have a sensible mechanism to serialize included resources.  Neither does it have a mechanism to query a subset of attributes.

This was resulting in some very large JSON payloads with duplicated unneeded data.  We avoid duplicating the data by preloading the related resources.