### PR TITLE
Display desktop session name on job page

### DIFF
--- a/client/src/JobSessionCard.js
+++ b/client/src/JobSessionCard.js
@@ -70,7 +70,7 @@ function SessionPending({ className }) {
 }
 
 function SessionComplete({ className, job }) {
-  const { error, loading } = useFetchDesktop(job.id);
+  const { data: session, error, loading } = useFetchDesktop(job.id);
 
   let content;
   if (loading) {
@@ -82,7 +82,7 @@ function SessionComplete({ className, job }) {
   }
 
   return (
-    <Layout className={className}>
+    <Layout className={className} session={session}>
       {content}
     </Layout>
   );

--- a/client/src/JobSessionCard.js
+++ b/client/src/JobSessionCard.js
@@ -44,7 +44,10 @@ function JobSessionCard({ className, job }) {
 function Layout({ button, children, className, session }) {
   let sessionName = null;
   if (session != null) {
-    sessionName = session.name || session.id.split('-')[0];
+    const sessionId = session.id.split('-')[0];
+    sessionName = session.name == null ?
+      sessionId :
+      `${session.name} (${sessionId})`;
   }
 
   return (


### PR DESCRIPTION
This PR changes the job page for desktop sessions to display the newly realised `name` property on desktops when the job is 'completed' (a mechanism was already in place for jobs that are running).
