### PR TITLE
Handle invalid templates/scripts better

### DIFF
--- a/api/app/serializers/job_serializer.rb
+++ b/api/app/serializers/job_serializer.rb
@@ -39,6 +39,8 @@ class JobSerializer < ApplicationSerializer
   attribute(:end_time) { object.metadata['actual_end_time'] }
   attribute(:merged_stderr) { object.stderr_merged? }
 
+  attribute(:script_id) { object.metadata['script_id'] }
+
   has_one :script
   has_one(:desktop, include_data: true) { object.find_desktop }
   has_one(:stdout_file) { object.find_stdout_file }

--- a/api/app/serializers/script_serializer.rb
+++ b/api/app/serializers/script_serializer.rb
@@ -33,6 +33,8 @@ class ScriptSerializer < ApplicationSerializer
 
   attribute(:name) { object.id }
 
+  attribute(:template_id) { object.metadata['template_id'] }
+
   has_one(:template)
   has_one(:note) { object.find_note }
   has_one(:content) { object.find_content }

--- a/client/src/JobMetadataCard.js
+++ b/client/src/JobMetadataCard.js
@@ -70,7 +70,12 @@ function JobMetadataCard({ className, job, onCancelled, onDeleted }) {
             name="Script"
             value={job.script ? job.script.attributes.name : null}
             format={(value) => (
-              value == null ? <i>Unknown</i> : (
+              value == null ? (
+                <span className="text-warning mr-1" title="Script is unknown">
+                  {job.attributes.scriptId}
+                  <i className="fa fa-exclamation-triangle ml-1"></i>
+                </span>
+              ) : (
                 <Link
                   to={`/scripts/${job.script.id}`}
                   title="View script"

--- a/client/src/JobSessionCard.js
+++ b/client/src/JobSessionCard.js
@@ -18,7 +18,7 @@ import { getTagValue, useInterval } from './utils';
 const activeStates = ['Active', 'Remote'];
 
 function isInteractive(script) {
-  return getTagValue(script.attributes.tags, 'script:type') === 'interactive';
+  return getTagValue(script?.attributes.tags, 'script:type') === 'interactive';
 }
 
 function JobSessionCard({ className, job }) {

--- a/client/src/JobsTable.js
+++ b/client/src/JobsTable.js
@@ -43,15 +43,7 @@ function JobsTable({ reloadJobs, jobs }) {
         Header: 'Script',
         accessor: 'script.attributes.name',
         Cell: ({ row, value }) => (
-          row.original.script == null ? <i>Unknown</i> : (
-            <Link
-              onClick={(ev) => ev.stopPropagation() }
-              title="View script"
-              to={`/scripts/${row.original.script.id}`}
-            >
-              {value}
-            </Link>
-          )
+          errorHandledScript({ row, value })
         ),
       },
       {
@@ -141,6 +133,31 @@ function JobsTable({ reloadJobs, jobs }) {
     {paginationControls}
     </>
   );
+}
+
+function errorHandledScript({ row, value }) {
+  const invalid = row.original.script == null;
+
+  if (invalid) {
+    return (
+      <p className="text-warning" title="Script is unknown">
+        <span className="text-nowrap">
+          {row.original.attributes.scriptId}
+          <i className="fa fa-exclamation-triangle ml-1"></i>
+        </span>
+      </p>
+    );
+  } else {
+    return (
+      <Link
+        onClick={(ev) => ev.stopPropagation() }
+        title="View script"
+        to={`/scripts/${row.original.script.id}`}
+      >
+        {value}
+      </Link>
+    );
+  }
 }
 
 function TableHeaders({ headerGroup }) {

--- a/client/src/ScriptCard.js
+++ b/client/src/ScriptCard.js
@@ -39,9 +39,9 @@ function ScriptMetadataCard({ onDeleted, script }) {
             value={script.template ? script.template.attributes.name : null}
             format={(value) => (
               value == null ? (
-                <span className="text-warning" title="Template is unknown">
+                <span className="text-warning mr-1" title="Template is unknown">
                   {script.template.id}
-                  <i class="fa fa-exclamation-triangle"></i>
+                  <i className="fa fa-exclamation-triangle ml-1"></i>
                 </span>
               ) : (
                 <Link

--- a/client/src/ScriptCard.js
+++ b/client/src/ScriptCard.js
@@ -38,7 +38,12 @@ function ScriptMetadataCard({ onDeleted, script }) {
             name="Template"
             value={script.template ? script.template.attributes.name : null}
             format={(value) => (
-              value == null ? <i>Unknown</i> : (
+              value == null ? (
+                <span className="text-warning" title="Template is unknown">
+                  {script.template.id}
+                  <i class="fa fa-exclamation-triangle"></i>
+                </span>
+              ) : (
                 <Link
                   to={`/templates/${script.template.id}`}
                   title="View template"

--- a/client/src/ScriptsTable.js
+++ b/client/src/ScriptsTable.js
@@ -130,8 +130,10 @@ function errorHandledTemplate({ row, value }) {
   if (invalid) {
     return (
       <p className={className} title="Template is unknown">
-        {row.original.attributes.templateId}
-        <i className="fa fa-exclamation-triangle"></i>
+        <span className="text-nowrap">
+          {row.original.attributes.templateId}
+          <i className="fa fa-exclamation-triangle ml-1"></i>
+        </span>
       </p>
     );
   } else {

--- a/client/src/ScriptsTable.js
+++ b/client/src/ScriptsTable.js
@@ -42,15 +42,7 @@ function ScriptsTable({ onRowSelect, scripts }) {
         Header: 'Template',
         accessor: 'template.attributes.name',
         Cell: ({ row, value }) => (
-          row.original.template == null ? <i>Unknown</i> : (
-            <Link
-              onClick={(ev) => ev.stopPropagation() }
-              title="View template"
-              to={`/templates/${row.original.template.id}`}
-            >
-              {value}
-            </Link>
-          )
+          errorHandledTemplate({ row, value })
         ),
       },
     ],
@@ -129,6 +121,30 @@ function ScriptsTable({ onRowSelect, scripts }) {
     {paginationControls}
     </>
   );
+}
+
+function errorHandledTemplate({ row, value }) {
+  const invalid = row.original.template == null;
+  const className = invalid ? "text-warning" : ""
+
+  if (invalid) {
+    return (
+      <p className={className} title="Template is invalid">
+        {row.original.attributes.templateId}
+        <i className="fa fa-exclamation-triangle"></i>
+      </p>
+    );
+  } else {
+    return (
+      <Link
+        onClick={(ev) => ev.stopPropagation() }
+        title="View template"
+        to={`/templates/${row.original.template.id}`}
+      >
+        {value}
+      </Link>
+    );
+  }
 }
 
 function TableHeaders({ headerGroup }) {

--- a/client/src/ScriptsTable.js
+++ b/client/src/ScriptsTable.js
@@ -129,7 +129,7 @@ function errorHandledTemplate({ row, value }) {
 
   if (invalid) {
     return (
-      <p className={className} title="Template is invalid">
+      <p className={className} title="Template is unknown">
         {row.original.attributes.templateId}
         <i className="fa fa-exclamation-triangle"></i>
       </p>

--- a/client/src/ScriptsTable.js
+++ b/client/src/ScriptsTable.js
@@ -125,11 +125,10 @@ function ScriptsTable({ onRowSelect, scripts }) {
 
 function errorHandledTemplate({ row, value }) {
   const invalid = row.original.template == null;
-  const className = invalid ? "text-warning" : ""
 
   if (invalid) {
     return (
-      <p className={className} title="Template is unknown">
+      <p className="text-warning" title="Template is unknown">
         <span className="text-nowrap">
           {row.original.attributes.templateId}
           <i className="fa fa-exclamation-triangle ml-1"></i>


### PR DESCRIPTION
This PR aims to improve the way that we handle displaying scripts and jobs when they are listed as having unknown templates and scripts, respectively.

Previously, if the template/script listed in the script/job's metadata was invalid/unknown, the UI would display `Unknown` in the place of its name. Now, if it is invalid/unknown, the template/script's ID is displayed in a warning colour, with a warning icon, and a tooltip telling the user that it is unknown.

**List output**
![Screenshot_2022-06-27_17-13-26](https://user-images.githubusercontent.com/12374447/175987444-39da96e1-2f84-49a1-85b2-3e8966b33b7e.png)

**Job show page**
![Screenshot_2022-06-27_17-13-44](https://user-images.githubusercontent.com/12374447/175987491-87c01601-f31d-41da-b2ad-c8f5f78fe05a.png)

**Script show page**
![Screenshot_2022-06-27_17-16-17](https://user-images.githubusercontent.com/12374447/175987648-29165e31-ab74-4960-90fc-f0434320c53b.png)


